### PR TITLE
Select Coalesce and Query Name for Tracing

### DIFF
--- a/QueryBuilder.Tests/QueryBuilderTest.cs
+++ b/QueryBuilder.Tests/QueryBuilderTest.cs
@@ -89,7 +89,7 @@ namespace SqlKata.Tests
                 {
                     new CoalesceFallback("CreatedDateUTC", FallbackType.Column),
                     new CoalesceFallback("NotSet", FallbackType.Value),
-                    new CoalesceFallback(new DateTime(2000, 1, 1), FallbackType.Value)
+                    new CoalesceFallback(new DateTime(2000, 1, 1), FallbackType.Value),
                 });
 
             var c = Compile(q);

--- a/QueryBuilder/Clauses/ColumnClause.cs
+++ b/QueryBuilder/Clauses/ColumnClause.cs
@@ -41,6 +41,56 @@ namespace SqlKata
         }
     }
 
+    public enum FallbackType
+    {
+        Column,
+        Value
+    }
+
+    public class CoalesceFallback
+    {
+        public FallbackType Type { get;set; }
+        public object Value { get;set; }
+
+        public CoalesceFallback()
+        {
+        }
+
+        public CoalesceFallback(string value)
+        {
+            Value = value;
+            Type = FallbackType.Column;
+        }
+
+        public CoalesceFallback(object value, FallbackType type)
+        {
+            Value = value;
+            Type = type;
+        }
+    }
+
+    public class CoalesceColumn : AbstractColumn
+    {
+        public Query Query { get; set; }
+        public List<CoalesceFallback> Fallbacks { get; set; }
+
+        public override object[] GetBindings(string engine)
+        {
+            return Query.GetBindings(engine).ToArray();
+        }
+
+        public override AbstractClause Clone()
+        {
+            return new CoalesceColumn
+            {
+                Engine = Engine,
+                Query = Query.Clone(),
+                Component = Component,
+                Fallbacks = Fallbacks
+            };
+        }
+    }
+
     public class RawColumn : AbstractColumn, RawInterface
     {
         public string Expression { get; set; }

--- a/QueryBuilder/Clauses/ColumnClause.cs
+++ b/QueryBuilder/Clauses/ColumnClause.cs
@@ -43,6 +43,7 @@ namespace SqlKata
 
     public enum FallbackType
     {
+        Query,
         Column,
         Value
     }
@@ -52,20 +53,22 @@ namespace SqlKata
         public FallbackType Type { get;set; }
         public object Value { get;set; }
 
-        public CoalesceFallback()
-        {
-        }
-
-        public CoalesceFallback(string value)
-        {
-            Value = value;
-            Type = FallbackType.Column;
-        }
-
         public CoalesceFallback(object value, FallbackType type)
         {
             Value = value;
             Type = type;
+        }
+
+        public CoalesceFallback(Query query)
+        {
+            Value = query;
+            Type = FallbackType.Query;
+        }
+
+        public CoalesceFallback(Func<Query, Query> callback)
+        {
+            Value = callback.Invoke(new Query());
+            Type = FallbackType.Query;
         }
     }
 

--- a/QueryBuilder/Compilers/SqlServerCompiler.cs
+++ b/QueryBuilder/Compilers/SqlServerCompiler.cs
@@ -70,7 +70,7 @@ namespace SqlKata.Compilers
             
             // Add the row_number select, and put back the bindings here if any
             subquery.SelectRaw(
-                    $"ROW_NUMBER() OVER ({orderStatement}) AS {WrapValue(rowNumberColName)}",
+                    $"ROW_NUMBER() OVER ({orderStatement}) AS {WrapColumn(rowNumberColName)}",
                     orderClause.SelectMany(x => x.GetBindings(EngineCode))
             );
 

--- a/QueryBuilder/Query.Select.cs
+++ b/QueryBuilder/Query.Select.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace SqlKata
 {
@@ -37,6 +39,34 @@ namespace SqlKata
             return this;
         }
 
+        public Query SelectCoalesce(Query query, string alias, params string[] fallbackColumns)
+        {
+            var fallbacks = fallbackColumns.Select(t => new CoalesceFallback(t, FallbackType.Column)).ToList();
+            return SelectCoalesce(query, alias, fallbacks);
+        }
+
+        public Query SelectCoalesce(Func<Query, Query> callback, string alias, params string[] fallbackColumns)
+        {
+            return SelectCoalesce(callback.Invoke(NewQuery()), alias, fallbackColumns);
+        }
+
+        public Query SelectCoalesce(Query query, string alias, List<CoalesceFallback> fallbacks)
+        {
+            Method = "select";
+
+            AddComponent("select", new CoalesceColumn
+            {
+                Query = query.As(alias),
+                Fallbacks = fallbacks
+            });
+
+            return this;
+        }
+
+        public Query SelectCoalesce(Func<Query, Query> callback, string alias, List<CoalesceFallback> fallbacks)
+        {
+            return SelectCoalesce(callback.Invoke(NewQuery()), alias, fallbacks);
+        }
 
         public Query Select(params object[] columns)
         {

--- a/QueryBuilder/Query.cs
+++ b/QueryBuilder/Query.cs
@@ -10,6 +10,7 @@ namespace SqlKata
         public bool IsDistinct { get; set; } = false;
         public string QueryAlias { get; set; }
         public string Method { get; set; }
+        public string Name { get; set; }
 
         protected override string[] bindingOrder
         {


### PR DESCRIPTION
I've implemented a SelectCoalesce method to allow the use of subqueries in coalesce. This could be enhanced to allow the use of more subqueries within select functions.

I've also added a Name property to the query. This prints out a comment in the SQL generated which allows us to locate SQL being executed during a trace.