### PR TITLE
Updated isNumber check in SqlResult.ToString method

### DIFF
--- a/QueryBuilder.Tests/QueryBuilderTest.cs
+++ b/QueryBuilder.Tests/QueryBuilderTest.cs
@@ -10,14 +10,14 @@ namespace SqlKata.Tests
     {
         private readonly Compiler _pg;
         private readonly MySqlCompiler _mysql;
-
-        public SqlServerCompiler _sqlsrv { get; private set; }
+        private readonly SqlServerCompiler _sqlsrv;
 
         private string[] Compile(Query q)
         {
-            return new[]{
-                 _sqlsrv.Compile(q.Clone()).ToString(),
-                 _mysql.Compile(q.Clone()).ToString(),
+            return new[]
+            {
+                _sqlsrv.Compile(q.Clone()).ToString(),
+                _mysql.Compile(q.Clone()).ToString(),
                 _pg.Compile(q.Clone()).ToString(),
             };
         }
@@ -37,6 +37,22 @@ namespace SqlKata.Tests
             Assert.Equal("SELECT [id], [name] FROM [users]", c[0]);
             Assert.Equal("SELECT `id`, `name` FROM `users`", c[1]);
             Assert.Equal("SELECT \"id\", \"name\" FROM \"users\"", c[2]);
+        }
+
+        [Fact]
+        public void BasicSelectWhereBindingIsEmptyOrNull()
+        {
+            var q = new Query()
+                .From("users")
+                .Select("id", "name")
+                .Where("author", "")
+                .OrWhere("author", null);
+
+            var c = Compile(q);
+
+            Assert.Equal("SELECT [id], [name] FROM [users] WHERE [author] = '' OR [author] IS NULL", c[0]);
+            Assert.Equal("SELECT `id`, `name` FROM `users` WHERE `author` = '' OR `author` IS NULL", c[1]);
+            Assert.Equal("SELECT \"id\", \"name\" FROM \"users\" WHERE \"author\" = '' OR \"author\" IS NULL", c[2]);
         }
 
         [Fact]
@@ -225,6 +241,19 @@ namespace SqlKata.Tests
         }
 
         [Fact]
+        public void InsertWithEmptyString()
+        {
+            var query = new Query("Books").AsInsert(
+                new[] { "Id", "Author", "ISBN", "Description" },
+                new object[] { 1, "Author 1", "123456", "" }
+            );
+
+            var c = Compile(query);
+
+            Assert.Equal("INSERT INTO [Books] ([Id], [Author], [ISBN], [Description]) VALUES (1, 'Author 1', 123456, '')", c[0]);
+        }
+
+        [Fact]
         public void UpdateWithNullValues()
         {
             var query = new Query("Books").Where("Id", 1).AsUpdate(
@@ -235,6 +264,19 @@ namespace SqlKata.Tests
             var c = Compile(query);
 
             Assert.Equal("UPDATE [Books] SET [Author] = 'Author 1', [Date] = NULL, [Version] = NULL WHERE [Id] = 1", c[0]);
+        }
+
+        [Fact]
+        public void UpdateWithEmptyString()
+        {
+            var query = new Query("Books").Where("Id", 1).AsUpdate(
+                new[] { "Author", "Description" },
+                new object[] { "Author 1", "" }
+            );
+
+            var c = Compile(query);
+
+            Assert.Equal("UPDATE [Books] SET [Author] = 'Author 1', [Description] = '' WHERE [Id] = 1", c[0]);
         }
 
         [Fact]

--- a/QueryBuilder/SqlResult.cs
+++ b/QueryBuilder/SqlResult.cs
@@ -60,7 +60,7 @@ namespace SqlKata
             });
         }
 
-        private bool IsNumber(string val)
+        private static bool IsNumber(string val)
         {
             return !string.IsNullOrEmpty(val) && val.All(char.IsDigit);
         }

--- a/QueryBuilder/SqlResult.cs
+++ b/QueryBuilder/SqlResult.cs
@@ -48,21 +48,21 @@ namespace SqlKata
                     return "NULL";
                 }
 
-                if (isNumber(value))
+                var textValue = value.ToString();
+
+                if (IsNumber(textValue))
                 {
-                    return value + "";
+                    return textValue;
                 }
 
-                return $"'{value}'";
+                return "'" + textValue + "'";
 
             });
         }
 
-        private bool isNumber(object val)
+        private bool IsNumber(string val)
         {
-            if (val == null) return false;
-
-            return val.ToString().All(x => char.IsDigit(x));
+            return !string.IsNullOrEmpty(val) && val.All(char.IsDigit);
         }
 
         public static SqlResult operator +(SqlResult a, SqlResult b)


### PR DESCRIPTION
Empty string was treated as number previously.
How it was:
```cs
var query = new Query("table").Select("col").Where("col", "");
new Compiler().Compile(query).ToString(); 
// will return `SELECT col FROM table WHERE col = ` 
// but should return `SELECT col FROM table WHERE col = ''` 
```




