### PR TITLE
Fix for sql parameter binding

### DIFF
--- a/QueryBuilder.Tests/CompilerTest.cs
+++ b/QueryBuilder.Tests/CompilerTest.cs
@@ -1,0 +1,43 @@
+﻿using SqlKata;
+using SqlKata.Compilers;
+using Xunit;
+
+namespace QueryBuilder.Tests
+{
+    public class CompilerTest
+    {
+        private readonly Compiler pgsql;
+        private readonly MySqlCompiler mysql;
+        private SqlServerCompiler mssql { get; }
+        
+        public CompilerTest()
+        {
+            mssql = new SqlServerCompiler();
+            mysql = new MySqlCompiler();
+            pgsql = new PostgresCompiler();
+        }
+        
+        private string[] Compile(Query q)
+        {
+            return new[]{
+                mssql.Compile(q.Clone()).ToString(),
+                mysql.Compile(q.Clone()).ToString(),
+                pgsql.Compile(q.Clone()).ToString(),
+            };
+        }
+        
+        [Fact]
+        public void Should_clear_query_parameters_after_compilation()
+        {
+            var laptops = new Query("Laptops").Where("Price", ">", 1000).ForPage(3);
+            var laptops2 = new Query("Laptops").Where("Price", ">", 1000).ForPage(4);
+
+            Compile(laptops);
+            Compile(laptops2);
+            
+            Assert.Empty(pgsql.bindings);
+            Assert.Empty(mysql.bindings);
+            Assert.Empty(mssql.bindings);
+        }
+    }
+}

--- a/QueryBuilder.Tests/QueryBuilder.Tests.csproj
+++ b/QueryBuilder.Tests/QueryBuilder.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <!-- Implicit import of directory.build.props doesn't seem to work from the linux cli, import manually -->
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
@@ -6,22 +6,18 @@
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' or '$(TargetFramework)' == 'netcoreapp2.0' ">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="1.0.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\QueryBuilder\QueryBuilder.csproj" />
     <ProjectReference Include="..\SqlKata.Execution\SqlKata.Execution.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Update="NuGet.Build.Tasks.Pack" Version="4.6.2" />
     <PackageReference Update="SourceLink.Create.CommandLine" Version="2.8.1" />

--- a/QueryBuilder/Compilers/Compiler.cs
+++ b/QueryBuilder/Compilers/Compiler.cs
@@ -11,7 +11,7 @@ namespace SqlKata.Compilers
         public string EngineCode;
 
         /// The list of bindings for the current compilation
-        protected List<object> bindings = new List<object>();
+        protected internal List<object> bindings = new List<object>();
 
         protected string OpeningIdentifier = "\"";
         protected string ClosingIdentifier = "\"";
@@ -85,7 +85,9 @@ namespace SqlKata.Compilers
             bindings = bindings.Select(x => x is NullValue ? null : x).ToList();
 
             sql = OnAfterCompile(sql, bindings);
-            return new SqlResult(sql, bindings);
+            var result = new SqlResult(sql, new List<object>(bindings));
+            bindings.Clear();
+            return result;
         }
 
         protected virtual Query OnBeforeCompile(Query query)

--- a/QueryBuilder/Properties/AssemblyInfo.cs
+++ b/QueryBuilder/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("QueryBuilder.Tests")]

--- a/QueryBuilder/QueryBuilder.csproj
+++ b/QueryBuilder/QueryBuilder.csproj
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Condition="'$(OS)' != 'Windows_NT'" Project="..\Directory.build.props"/>
+  <Import Condition="'$(OS)' != 'Windows_NT'" Project="..\Directory.build.props" />
   <PropertyGroup>
     <PackageId>SqlKata</PackageId>
     <PackageTags>sql;query-builder;dynamic-query</PackageTags>
@@ -11,10 +11,10 @@
     <TargetFrameworks>netstandard1.3;net451</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0"/>
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="NuGet.Build.Tasks.Pack" Version="4.6.2"/>
-    <PackageReference Update="SourceLink.Create.CommandLine" Version="2.8.1"/>
+    <PackageReference Update="NuGet.Build.Tasks.Pack" Version="4.6.2" />
+    <PackageReference Update="SourceLink.Create.CommandLine" Version="2.8.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes issue #80.
The parameter bindings were not cleared after each compilation. This has caused two issues:
- the pagination was broken, after the second page the data repeats, because only the first two parameters were being injected in place of the placeholders.
- longer sessions with the database server were returning an error after some time saying 
```
The incoming request has too many parameters. The server supports a maximum of 2100 parameters. Reduce the number of parameters and resend the request.
```