### PR TITLE
Updated ToString() to check number type

### DIFF
--- a/QueryBuilder.Tests/QueryBuilderTest.cs
+++ b/QueryBuilder.Tests/QueryBuilderTest.cs
@@ -176,9 +176,9 @@ public class QueryBuilderTest
 
         Assert.Equal("WITH `range` AS (SELECT `Id` FROM `seqtbl` WHERE `Id` < 33) \nSELECT * FROM `Races` WHERE `RaceAuthor` IN (SELECT `Name` FROM `Users` WHERE `Status` = 'Available') AND `Id` > 55 AND `Value` BETWEEN 18 AND 24", c[1]);
 
-        Assert.Equal("WITH \"range\" AS (SELECT \"d\" FROM generate_series(1, 33) as d) \nSELECT * FROM \"Races\" WHERE \"Name\" = 3778 AND \"Id\" > 55 AND \"Value\" BETWEEN 18 AND 24", c[2]);
+        Assert.Equal("WITH \"range\" AS (SELECT \"d\" FROM generate_series(1, 33) as d) \nSELECT * FROM \"Races\" WHERE \"Name\" = '3778' AND \"Id\" > 55 AND \"Value\" BETWEEN 18 AND 24", c[2]);
 
-        Assert.Equal("WITH \"RANGE\" AS (SELECT \"D\" FROM generate_series(1, 33) as d) \nSELECT * FROM \"RACES\" WHERE \"NAME\" = 3778 AND \"ID\" > 55 AND \"VALUE\" BETWEEN 18 AND 24", c[3]);
+        Assert.Equal("WITH \"RANGE\" AS (SELECT \"D\" FROM generate_series(1, 33) as d) \nSELECT * FROM \"RACES\" WHERE \"NAME\" = '3778' AND \"ID\" > 55 AND \"VALUE\" BETWEEN 18 AND 24", c[3]);
     }
 
     [Fact]
@@ -196,7 +196,7 @@ public class QueryBuilderTest
 
         var c = Compile(query);
 
-        Assert.Equal($"WITH [OldBooks] AS (SELECT * FROM [Books] WHERE [Date] < '{now}') \nUPDATE [Books] SET [Price] = 150 WHERE [Price] > 100", c[0]);
+        Assert.Equal($"WITH [OldBooks] AS (SELECT * FROM [Books] WHERE [Date] < '{now}') \nUPDATE [Books] SET [Price] = '150' WHERE [Price] > 100", c[0]);
     }
 
     [Fact]

--- a/QueryBuilder.Tests/QueryBuilderTest.cs
+++ b/QueryBuilder.Tests/QueryBuilderTest.cs
@@ -349,10 +349,10 @@ public class QueryBuilderTest
 
         var c = Compile(query);
 
-        Assert.Equal("INSERT INTO [Books] ([Id], [Author], [ISBN], [Description]) VALUES (1, 'Author 1', 123456, '')", c[0]);
+        Assert.Equal("INSERT INTO [Books] ([Id], [Author], [ISBN], [Description]) VALUES (1, 'Author 1', '123456', '')", c[0]);
 
 
-        Assert.Equal("INSERT INTO \"BOOKS\" (\"ID\", \"AUTHOR\", \"ISBN\", \"DESCRIPTION\") VALUES (1, 'Author 1', 123456, '')", c[3]);
+        Assert.Equal("INSERT INTO \"BOOKS\" (\"ID\", \"AUTHOR\", \"ISBN\", \"DESCRIPTION\") VALUES (1, 'Author 1', '123456', '')", c[3]);
     }
 
     [Fact]

--- a/QueryBuilder.Tests/QueryBuilderTest.cs
+++ b/QueryBuilder.Tests/QueryBuilderTest.cs
@@ -333,10 +333,10 @@ public class QueryBuilderTest
 
         var c = Compile(query);
 
-        Assert.Equal("INSERT INTO [Books] ([Id], [Author], [ISBN], [Date]) VALUES (1, 'Author 1', 123456, NULL)", c[0]);
+        Assert.Equal("INSERT INTO [Books] ([Id], [Author], [ISBN], [Date]) VALUES (1, 'Author 1', '123456', NULL)", c[0]);
 
 
-        Assert.Equal("INSERT INTO \"BOOKS\" (\"ID\", \"AUTHOR\", \"ISBN\", \"DATE\") VALUES (1, 'Author 1', 123456, NULL)", c[3]);
+        Assert.Equal("INSERT INTO \"BOOKS\" (\"ID\", \"AUTHOR\", \"ISBN\", \"DATE\") VALUES (1, 'Author 1', '123456', NULL)", c[3]);
     }
 
     [Fact]

--- a/QueryBuilder/SqlResult.cs
+++ b/QueryBuilder/SqlResult.cs
@@ -36,7 +36,18 @@ namespace SqlKata
                 return namedParams;
             }
         }
-
+         private static Type[] numberTypes = new Type[]
+        {
+            typeof(int),
+            typeof(long),
+            typeof(decimal),
+            typeof(double),
+            typeof(float),
+            typeof(short),
+            typeof(ushort),
+            typeof(ulong),
+        };
+        
         public override string ToString()
         {
             return Helper.ReplaceAll(RawSql, "?", i =>
@@ -52,7 +63,7 @@ namespace SqlKata
                 {
                     return "NULL";
                 }
-                else if (IsNumber(value.ToString()))
+                else if (numberTypes.Contains(value.GetType()))
                 {
                     return value.ToString();
                 }
@@ -74,12 +85,7 @@ namespace SqlKata
 
             });
         }
-
-        private static bool IsNumber(string val)
-        {
-            return !string.IsNullOrEmpty(val) && double.TryParse(val, out double num);
-        }
-
+        
         public static SqlResult operator +(SqlResult a, SqlResult b)
         {
             var sql = a.RawSql + ";" + b.RawSql;


### PR DESCRIPTION
Instead of parsing the binding string value I changed it to check it's type instead. This is (in my opinion) a more reliable check. Also, you run into potential 'Error converting data type varchar to numeric' type issues when debugging, thus having to manually edit the query.