### PR TITLE
Leading newline character before every join

### DIFF
--- a/QueryBuilder.Tests/QueryBuilderTest.cs
+++ b/QueryBuilder.Tests/QueryBuilderTest.cs
@@ -659,7 +659,7 @@ namespace SqlKata.Tests
 
             var c = Compile(query);
 
-            Assert.Equal("SELECT * FROM [users] INNER JOIN [countries] ON ([countries].[id] = [users].[country_id])",
+            Assert.Equal("SELECT * FROM [users] \nINNER JOIN [countries] ON ([countries].[id] = [users].[country_id])",
                 c[0]);
         }
 

--- a/QueryBuilder.Tests/QueryJoinTest.cs
+++ b/QueryBuilder.Tests/QueryJoinTest.cs
@@ -33,9 +33,9 @@ namespace SqlKata.Tests
 
             var c = Compile(q);
 
-            Assert.Equal("SELECT * FROM [users] INNER JOIN [countries] ON [countries].[id] = [users].[country_id]",
+            Assert.Equal("SELECT * FROM [users] \nINNER JOIN [countries] ON [countries].[id] = [users].[country_id]",
                 c[0]);
-            Assert.Equal("SELECT * FROM `users` INNER JOIN `countries` ON `countries`.`id` = `users`.`country_id`",
+            Assert.Equal("SELECT * FROM `users` \nINNER JOIN `countries` ON `countries`.`id` = `users`.`country_id`",
                 c[1]);
         }
 
@@ -51,18 +51,18 @@ namespace SqlKata.Tests
 
             var c = Compile(q);
 
-            Assert.Equal($"SELECT * FROM [users] {output} [countries] ON [countries].[id] = [users].[country_id]",
+            Assert.Equal($"SELECT * FROM [users] \n{output} [countries] ON [countries].[id] = [users].[country_id]",
                 c[0]);
 
-            Assert.Equal($"SELECT * FROM `users` {output} `countries` ON `countries`.`id` = `users`.`country_id`",
+            Assert.Equal($"SELECT * FROM `users` \n{output} `countries` ON `countries`.`id` = `users`.`country_id`",
                 c[1]);
 
             Assert.Equal(
-                $"SELECT * FROM \"users\" {output} \"countries\" ON \"countries\".\"id\" = \"users\".\"country_id\"",
+                $"SELECT * FROM \"users\" \n{output} \"countries\" ON \"countries\".\"id\" = \"users\".\"country_id\"",
                 c[2]);
 
             Assert.Equal(
-                $"SELECT * FROM \"USERS\" {output} \"COUNTRIES\" ON \"COUNTRIES\".\"ID\" = \"USERS\".\"COUNTRY_ID\"",
+                $"SELECT * FROM \"USERS\" \n{output} \"COUNTRIES\" ON \"COUNTRIES\".\"ID\" = \"USERS\".\"COUNTRY_ID\"",
                 c[3]);
         }
     }

--- a/QueryBuilder/Compilers/Compiler.cs
+++ b/QueryBuilder/Compilers/Compiler.cs
@@ -78,7 +78,6 @@ namespace SqlKata.Compilers
                     this.CompileUnion(ctx),
                 }
                .Where(x => x != null)
-               .Select(x => x.Trim())
                .Where(x => !string.IsNullOrEmpty(x))
                .ToList();
 

--- a/QueryBuilder/Compilers/Compiler.cs
+++ b/QueryBuilder/Compilers/Compiler.cs
@@ -432,7 +432,7 @@ namespace SqlKata.Compilers
                 .GetComponents<BaseJoin>("join", EngineCode)
                 .Select(x => CompileJoin(ctx, x.Join));
 
-            return string.Join("\n", joins);
+            return "\n" + string.Join("\n", joins);
         }
 
         public virtual string CompileJoin(SqlResult ctx, Join join, bool isNested = false)


### PR DESCRIPTION
Currently results in a trailing space character ` ` on the line before the first join line, which is not ideal.

WIP