### PR TITLE
Optimize MethodsCache

### DIFF
--- a/QueryBuilder/Compilers/Compiler.Conditions.cs
+++ b/QueryBuilder/Compilers/Compiler.Conditions.cs
@@ -7,41 +7,61 @@ namespace SqlKata.Compilers
 {
     public partial class Compiler
     {
+        private class CompileConditionMethods
+        {
+            private readonly Type compilerType;
+            private readonly Dictionary<string, MethodInfo> methodsCache = new Dictionary<string, MethodInfo>();
+            private readonly object syncRoot = new object();
 
-        /// <summary>
-        /// Cache the method lookup to improve performance
-        /// </summary>
-        /// <returns></returns>
-        protected Dictionary<string, MethodInfo> methodsCache = new Dictionary<string, MethodInfo>();
+            public CompileConditionMethods(Type compilerType)
+            {
+                this.compilerType = compilerType;
+            }
+
+            public MethodInfo GetMethodInfo(Type clauseType, string methodName)
+            {
+                // The cache key should take the type and the method name into consideration
+                var cacheKey = methodName + "::" + clauseType.FullName;
+
+                if (methodsCache.ContainsKey(cacheKey))
+                {
+                    return methodsCache[cacheKey];
+                }
+
+                lock (syncRoot)
+                {
+                    if (methodsCache.ContainsKey(cacheKey))
+                    {
+                        return methodsCache[cacheKey];
+                    }
+
+                    return methodsCache[cacheKey] = FindMethodInfo(clauseType, methodName);
+                }
+            }
+
+            private MethodInfo FindMethodInfo(Type clauseType, string methodName)
+            {
+                MethodInfo methodInfo = compilerType
+                    .GetRuntimeMethods()
+                    .FirstOrDefault(x => x.Name == methodName);
+
+                if (methodInfo == null)
+                {
+                    throw new Exception($"Failed to locate a compiler for {methodName}.");
+                }
+
+                if (clauseType.IsConstructedGenericType && methodInfo.GetGenericArguments().Any())
+                {
+                    methodInfo = methodInfo.MakeGenericMethod(clauseType.GenericTypeArguments);
+                }
+
+                return methodInfo;
+            }
+        }
 
         protected virtual MethodInfo FindCompilerMethodInfo(Type clauseType, string methodName)
         {
-            // The cache key should take the type and the method name into consideration
-            var cacheKey = methodName + "::" + clauseType.FullName;
-
-            if (methodsCache.ContainsKey(cacheKey))
-            {
-                return methodsCache[cacheKey];
-            }
-
-            MethodInfo methodInfo = this.GetType()
-                .GetRuntimeMethods()
-                .Where(x => x.Name == methodName)
-                .FirstOrDefault();
-
-            if (methodInfo == null)
-            {
-                throw new Exception($"Failed to locate a compiler for {methodName}.");
-            }
-
-            if (clauseType.IsConstructedGenericType && methodInfo.GetGenericArguments().Any())
-            {
-                methodInfo = methodInfo.MakeGenericMethod(clauseType.GenericTypeArguments);
-            }
-
-            methodsCache[cacheKey] = methodInfo;
-
-            return methodInfo;
+            return compileConditionMethodsProvider.GetMethodInfo(clauseType, methodName);
         }
 
         protected virtual string CompileCondition(SqlResult ctx, AbstractCondition clause)

--- a/QueryBuilder/Compilers/Compiler.cs
+++ b/QueryBuilder/Compilers/Compiler.cs
@@ -8,6 +8,8 @@ namespace SqlKata.Compilers
 
     public partial class Compiler
     {
+        private readonly CompileConditionMethods compileConditionMethodsProvider;
+
         public string EngineCode;
         protected string OpeningIdentifier = "\"";
         protected string ClosingIdentifier = "\"";
@@ -16,6 +18,7 @@ namespace SqlKata.Compilers
 
         public Compiler()
         {
+            compileConditionMethodsProvider = new CompileConditionMethods(GetType());
         }
 
         public virtual SqlResult Compile(Query query)


### PR DESCRIPTION
1. Use thread-safe logic for FindCompilerMethodInfo