### PR TITLE
Added a generic Oracle class 

### DIFF
--- a/QueryBuilder.Tests/OracleLegacyLimit.cs
+++ b/QueryBuilder.Tests/OracleLegacyLimit.cs
@@ -5,83 +5,81 @@ using Xunit;
 
 namespace SqlKata.Tests
 {
-    public class Oracle11gLimitTests
+    public class OracleLegacyLimitTests
     {
         private const string TableName = "Table";
         private const string SqlPlaceholder = "GENERATED_SQL";
 
-        private Oracle11gCompiler compiler = new Oracle11gCompiler();
-
-        [Fact]
-        public void CompileLimitThrowsException()
+        private OracleCompiler compiler = new OracleCompiler()
         {
-            // Arrange:
-            var query = new Query(TableName);
-            var ctx = new SqlResult { Query = query };
-
-            // Act:
-            Assert.Throws<NotSupportedException>(() => compiler.CompileLimit(ctx));
-
-            // Assert: Assertion is handled by Throws
-        }
+            UseLegacyPagination = true
+        };
 
         [Fact]
-        public void WithNoLimitNorOffset()
+        public void NoLimitNorOffset()
         {
             // Arrange:
             var query = new Query(TableName);
             var ctx = new SqlResult { Query = query, RawSql = SqlPlaceholder };
 
-            // Act:
-            compiler.ApplyLimit(ctx);
+            // Act & Assert:
+            var result = compiler.CompileLimit(ctx);
+            compiler.ApplyLegacyLimit(ctx, 0, 0);
 
-            // Assert:
+            Assert.Null(result);
             Assert.Equal(SqlPlaceholder, ctx.RawSql);
         }
 
         [Fact]
-        public void WithNoOffset()
+        public void LimitOnly()
         {
             // Arrange:
             var query = new Query(TableName).Limit(10);
             var ctx = new SqlResult { Query = query, RawSql = SqlPlaceholder };
 
             // Act:
-            compiler.ApplyLimit(ctx);
+            var result = compiler.CompileLimit(ctx);
+            compiler.ApplyLegacyLimit(ctx, 10, 0);
 
             // Assert:
+            Assert.Null(result);
             Assert.Matches($"SELECT \\* FROM \\({SqlPlaceholder}\\) WHERE ROWNUM <= ?", ctx.RawSql);
             Assert.Equal(10, ctx.Bindings[0]);
             Assert.Single(ctx.Bindings);
         }
 
         [Fact]
-        public void WithNoLimit()
+        public void OffsetOnly()
         {
             // Arrange:
             var query = new Query(TableName).Offset(20);
             var ctx = new SqlResult { Query = query, RawSql = SqlPlaceholder };
 
-            // Act:
-            compiler.ApplyLimit(ctx);
+            // Act & Assert:
+            var result = compiler.CompileLimit(ctx);
+            compiler.ApplyLegacyLimit(ctx, 0, 20);
 
             // Assert:
+            //Assert.Null(result);
             Assert.Matches($"SELECT \\* FROM \\(SELECT \"(SqlKata_.*__)\"\\.\\*, ROWNUM \"(SqlKata_.*__)\" FROM \\({SqlPlaceholder}\\) \"(SqlKata_.*__)\"\\) WHERE \"(SqlKata_.*__)\" > \\?", ctx.RawSql);
             Assert.Equal(20, ctx.Bindings[0]);
             Assert.Single(ctx.Bindings);
+
         }
 
         [Fact]
-        public void WithLimitAndOffset()
+        public void LimitAndOffset()
         {
             // Arrange:
             var query = new Query(TableName).Limit(5).Offset(20);
             var ctx = new SqlResult { Query = query, RawSql = SqlPlaceholder };
 
-            // Act:
-            compiler.ApplyLimit(ctx);
+            // Act & Assert:
+            var result = compiler.CompileLimit(ctx);
+            compiler.ApplyLegacyLimit(ctx, 5, 20);
 
             // Assert:
+            Assert.Null(result);
             Assert.Matches($"SELECT \\* FROM \\(SELECT \"(SqlKata_.*__)\"\\.\\*, ROWNUM \"(SqlKata_.*__)\" FROM \\({SqlPlaceholder}\\) \"(SqlKata_.*__)\" WHERE ROWNUM <= \\?\\) WHERE \"(SqlKata_.*__)\" > \\?", ctx.RawSql);
             Assert.Equal(25, ctx.Bindings[0]);
             Assert.Equal(20, ctx.Bindings[1]);

--- a/QueryBuilder.Tests/OracleLimitTests.cs
+++ b/QueryBuilder.Tests/OracleLimitTests.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using SqlKata;
+using SqlKata.Compilers;
+using Xunit;
+
+namespace SqlKata.Tests
+{
+    public class OracleLimitTests
+    {
+        private const string TableName = "Table";
+        private const string SqlPlaceholder = "GENERATED_SQL";
+
+        private OracleCompiler compiler = new OracleCompiler();
+
+        [Fact]
+        public void NoLimitNorOffset()
+        {
+            // Arrange:
+            var query = new Query(TableName);
+            var ctx = new SqlResult { Query = query, RawSql = SqlPlaceholder };
+
+            // Act & Assert:
+            Assert.Null(compiler.CompileLimit(ctx));
+        }
+
+        [Fact]
+        public void LimitOnly()
+        {
+            // Arrange:
+            var query = new Query(TableName).Limit(10);
+            var ctx = new SqlResult { Query = query, RawSql = SqlPlaceholder };
+
+            //  Act & Assert:
+            Assert.EndsWith("OFFSET ? ROWS FETCH NEXT ? ROWS ONLY", compiler.CompileLimit(ctx));
+            Assert.Equal(2, ctx.Bindings.Count);
+            Assert.Equal(0, ctx.Bindings[0]);
+            Assert.Equal(10, ctx.Bindings[1]);
+        }
+
+        [Fact]
+        public void OffsetOnly()
+        {
+            // Arrange:
+            var query = new Query(TableName).Offset(20);
+            var ctx = new SqlResult { Query = query, RawSql = SqlPlaceholder };
+
+            // Act & Assert:
+            Assert.EndsWith("OFFSET ? ROWS", compiler.CompileLimit(ctx));
+
+            Assert.Single(ctx.Bindings);
+            Assert.Equal(20, ctx.Bindings[0]);
+        }
+
+        [Fact]
+        public void LimitAndOffset()
+        {
+            // Arrange:
+            var query = new Query(TableName).Limit(5).Offset(20);
+            var ctx = new SqlResult { Query = query, RawSql = SqlPlaceholder };
+
+            // Act & Assert:
+            Assert.EndsWith("OFFSET ? ROWS FETCH NEXT ? ROWS ONLY", compiler.CompileLimit(ctx));
+
+            Assert.Equal(2, ctx.Bindings.Count);
+            Assert.Equal(20, ctx.Bindings[0]);
+            Assert.Equal(5, ctx.Bindings[1]);
+
+            compiler.CompileLimit(ctx);
+        }
+    }
+}

--- a/QueryBuilder/Compilers/OracleCompiler.cs
+++ b/QueryBuilder/Compilers/OracleCompiler.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using SqlKata.Compilers.Bindings;
+
+// ReSharper disable InconsistentNaming
+
+namespace SqlKata.Compilers
+{
+    public sealed class OracleCompiler : Compiler
+    {
+        public OracleCompiler() : base(
+            new OracleResultBinder()
+            )
+        {
+            ColumnAsKeyword = "";
+            TableAsKeyword = "";
+        }
+
+        public override string EngineCode { get; } = "oracle";
+        public bool UseLegacyPagination { get; set; } = false;
+
+        protected override SqlResult CompileSelectQuery(Query query)
+        {
+            if (!UseLegacyPagination)
+            {
+                return base.CompileSelectQuery(query);
+            }
+
+            query = query.Clone();
+
+            var limit = query.GetLimit(EngineCode);
+            var offset = query.GetOffset(EngineCode);
+
+            query.ClearComponent("limit");
+
+            var ctx = new SqlResult
+            {
+                Query = query,
+            };
+
+            var result = base.CompileSelectQuery(query);
+
+            ApplyLegacyLimit(result, limit, offset);
+
+            return ctx;
+        }
+
+        public override string CompileLimit(SqlResult ctx)
+        {
+            if (UseLegacyPagination)
+            {
+                // in pre-12c versions of Oracle, limit is handled by ROWNUM techniques
+                return null;
+            }
+
+            var limit = ctx.Query.GetLimit(EngineCode);
+            var offset = ctx.Query.GetOffset(EngineCode);
+
+            if (limit == 0 && offset == 0)
+            {
+                return null;
+            }
+
+            var safeOrder = "";
+            if (!ctx.Query.HasComponent("order"))
+            {
+                safeOrder = "ORDER BY (SELECT 0) ";
+            }
+
+            if (limit == 0)
+            {
+                ctx.Bindings.Add(offset);
+                return $"{safeOrder}OFFSET ? ROWS";
+            }
+
+            ctx.Bindings.Add(offset);
+            ctx.Bindings.Add(limit);
+
+            return $"{safeOrder}OFFSET ? ROWS FETCH NEXT ? ROWS ONLY";
+        }
+
+        internal void ApplyLegacyLimit(SqlResult ctx, int limit, int offset)
+        {
+
+            if (limit == 0 && offset == 0)
+            {
+                return;
+            }
+            
+            //@todo replace with alias generator
+            var alias1 = WrapValue("SqlKata_A__");
+            var alias2 = WrapValue("SqlKata_B__"); 
+
+            string newSql;
+            if (limit == 0)
+            {
+                newSql = $"SELECT * FROM (SELECT {alias1}.*, ROWNUM {alias2} FROM ({ctx.RawSql}) {alias1}) WHERE {alias2} > ?";
+                ctx.Bindings.Add(offset);
+            } else if (offset == 0)
+            {
+                newSql = $"SELECT * FROM ({ctx.RawSql}) WHERE ROWNUM <= ?";
+                ctx.Bindings.Add(limit);
+            }
+            else
+            {
+                newSql = $"SELECT * FROM (SELECT {alias1}.*, ROWNUM {alias2} FROM ({ctx.RawSql}) {alias1} WHERE ROWNUM <= ?) WHERE {alias2} > ?";
+                ctx.Bindings.Add(limit +  offset);
+                ctx.Bindings.Add(offset);
+            }
+
+            ctx.RawSql = newSql;
+        }
+    }
+
+    public static class OracleCompilerExtensions
+    {
+        public static string ENGINE_CODE = "oracle";
+
+        public static Query ForOracle(this Query src, Func<Query, Query> fn)
+        {
+            return src.For(ENGINE_CODE, fn);
+        }
+    }
+}

--- a/sqlkata.sln
+++ b/sqlkata.sln
@@ -3,11 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QueryBuilder", "QueryBuilder\QueryBuilder.csproj", "{2D0657E1-7046-4B45-BAF3-90291BD74E0B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QueryBuilder", "QueryBuilder\QueryBuilder.csproj", "{2D0657E1-7046-4B45-BAF3-90291BD74E0B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QueryBuilder.Tests", "QueryBuilder.Tests\QueryBuilder.Tests.csproj", "{61B3CBF1-7471-4F7B-B4AE-8D7F1E124371}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QueryBuilder.Tests", "QueryBuilder.Tests\QueryBuilder.Tests.csproj", "{61B3CBF1-7471-4F7B-B4AE-8D7F1E124371}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SqlKata.Execution", "SqlKata.Execution\SqlKata.Execution.csproj", "{B6DF0569-6040-4EAF-A38B-E4DEB8DC76E0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SqlKata.Execution", "SqlKata.Execution\SqlKata.Execution.csproj", "{B6DF0569-6040-4EAF-A38B-E4DEB8DC76E0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
This new class supports both LIMIT/OFFSET (12c) and legacy (< 12c) ROWNUMBER pagination syntax similar to how it is done for SqlServer. Also added additional tests and moved them (together with the existing Oracle11gCompiler tests) into the SqlKata.Tests namespace.

This is a step closer to full-blown Oracle support IMO #56 