### PR TITLE
Fix lastval in PostgresCompiler for SqlKata.Execution

### DIFF
--- a/QueryBuilder/Compilers/PostgresCompiler.cs
+++ b/QueryBuilder/Compilers/PostgresCompiler.cs
@@ -4,7 +4,7 @@ namespace SqlKata.Compilers
     {
         public PostgresCompiler()
         {
-            LastId = "SELECT lastval()";
+            LastId = "SELECT lastval() AS id";
         }
 
         public override string EngineCode { get; } = EngineCodes.PostgreSql;


### PR DESCRIPTION
Now `_db.Query("...").InsertGetId<int>(obj);` always returns 0 (i.e. `default(int)`), because sql `"SELECT lastval()"` returns lastval in column named "lastval" which doesn't map to `InsertGetIdRow<T>.Id`.

Tested on postgresql 10.