### PR TITLE
Support includes for *dynamic* queries

### DIFF
--- a/Program/Program.cs
+++ b/Program/Program.cs
@@ -39,17 +39,25 @@ namespace Program
 
             // SQLiteConnection.CreateFile("Demo.db");
 
-            connection = new SQLiteConnection("Data Source=Demo.db");
+            // connection = new SQLiteConnection("Data Source=Demo.db");
 
-            var db = new QueryFactory(connection, new SqliteCompiler());
+            var db = new QueryFactory(connection, new SqlServerCompiler());
 
-            // db.Statement("create table accounts(id integer primary key,name text,currency_id text);");
+            db.Logger = result =>
+            {
+                Console.WriteLine(result.ToString());
+            };
 
-            db.Logger = q => Console.WriteLine(q.ToString());
+            var accounts = db.Query("Accounts")
+                .WhereNotNull("BankId")
+                .Include("bank",
+                    db.Query("Banks").Include("Country", db.Query("Countries"))
+                        .Select("Id", "Name", "CountryId")
+                )
+                .Select("Id", "Name", "BankId")
+                .OrderByDesc("Id").Limit(10).Get();
 
-            var accounts = db.Query("Accounts").OrderByDesc("Id").Offset(10).Get();
-
-            Console.WriteLine(JsonConvert.SerializeObject(accounts));
+            Console.WriteLine(JsonConvert.SerializeObject(accounts, Formatting.Indented));
 
         }
 

--- a/QueryBuilder/Include.cs
+++ b/QueryBuilder/Include.cs
@@ -1,0 +1,10 @@
+namespace SqlKata
+{
+    public class Include
+    {
+        public string Name { get; set; }
+        public Query Query { get; set; }
+        public string ForeignKey { get; set; }
+        public string LocalKey { get; set; }
+    }
+}

--- a/QueryBuilder/Query.cs
+++ b/QueryBuilder/Query.cs
@@ -10,6 +10,7 @@ namespace SqlKata
         public string QueryAlias { get; set; }
         public string Method { get; set; } = "select";
         public string QueryComment { get; set; }
+        public List<Include> Includes = new List<Include>();
 
         public Query() : base()
         {
@@ -56,6 +57,7 @@ namespace SqlKata
             clone.QueryAlias = QueryAlias;
             clone.IsDistinct = IsDistinct;
             clone.Method = Method;
+            clone.Includes = Includes;
             return clone;
         }
 
@@ -306,6 +308,24 @@ namespace SqlKata
         public override Query NewQuery()
         {
             return new Query();
+        }
+
+        public Query Include(string relationName, Query query, string foreignKey = null, string localKey = "Id")
+        {
+            if (foreignKey == null)
+            {
+                foreignKey = relationName + "Id";
+            }
+
+            Includes.Add(new Include
+            {
+                Name = relationName,
+                LocalKey = localKey,
+                ForeignKey = foreignKey,
+                Query = query,
+            });
+
+            return this;
         }
 
     }

--- a/SqlKata.Execution/QueryFactory.cs
+++ b/SqlKata.Execution/QueryFactory.cs
@@ -52,6 +52,7 @@ namespace SqlKata.Execution
             xQuery.QueryAlias = query.QueryAlias;
             xQuery.IsDistinct = query.IsDistinct;
             xQuery.Method = query.Method;
+            xQuery.Includes = query.Includes;
 
             xQuery.SetEngineScope(query.EngineScope);
 


### PR DESCRIPTION
Provide the **Include** feature,

```cs
var postsWithAuthors = db.Query("Posts").Include("Author", db.Query("Authors")).Get();
```

will returns

```json
[
    {
        "Id": 1,
        "Name": "How to include nested rows in SqlKata",
        "AuthorId": 22,
        "Author": {
            "Id": 22,
            "Name": "Ahmad"
        }
    }
]
```

Isn't awesome ? 😎
