### PR TITLE
Include the Engine when cloning a FromClause

### DIFF
--- a/QueryBuilder.Tests/GeneralTests.cs
+++ b/QueryBuilder.Tests/GeneralTests.cs
@@ -348,5 +348,20 @@ namespace SqlKata.Tests
             Assert.Equal(10, limits.Single().Offset);
             Assert.Equal(5, limits.Single().Limit);
         }
+
+        [Fact]
+        public void LimitOffset_Takes_Generic_If_Needed()
+        {
+            var query = new Query("mytable")
+                .Limit(5)
+                .Offset(10)
+                .ForPostgreSql(q => q.Limit(20));
+
+            var engines = new[] { EngineCodes.MySql, EngineCodes.PostgreSql };
+            var c = Compilers.Compile(engines, query);
+
+            Assert.Equal("SELECT * FROM `mytable` LIMIT 5 OFFSET 10", c[EngineCodes.MySql].ToString());
+            Assert.Equal("SELECT * FROM \"mytable\" LIMIT 20 OFFSET 10", c[EngineCodes.PostgreSql].ToString());
+        }
     }
 }

--- a/QueryBuilder.Tests/GeneralTests.cs
+++ b/QueryBuilder.Tests/GeneralTests.cs
@@ -160,5 +160,50 @@ namespace SqlKata.Tests
 
             Assert.Equal("[My Table One] AS [Table One]", compiler.Wrap("My Table One as Table One"));
         }
+
+        [Fact]
+        public void CompilerSpecificFrom()
+        {
+            var query = new Query()
+                .ForSqlServer(q => q.From("mssql"))
+                .ForPostgreSql(q => q.From("pgsql"))
+                .ForMySql(q => q.From("mysql"));
+            var engines = new[] { EngineCodes.SqlServer, EngineCodes.MySql, EngineCodes.PostgreSql };
+            var c = Compilers.Compile(engines, query);
+
+            Assert.Equal("SELECT * FROM [mssql]", c[EngineCodes.SqlServer].RawSql);
+            Assert.Equal("SELECT * FROM \"pgsql\"", c[EngineCodes.PostgreSql].RawSql);
+            Assert.Equal("SELECT * FROM `mysql`", c[EngineCodes.MySql].RawSql);
+        }
+
+        [Fact]
+        public void CompilerSpecificFromRaw()
+        {
+            var query = new Query()
+                .ForSqlServer(q => q.FromRaw("[mssql]"))
+                .ForPostgreSql(q => q.FromRaw("[pgsql]"))
+                .ForMySql(q => q.FromRaw("[mysql]"));
+            var engines = new[] { EngineCodes.SqlServer, EngineCodes.MySql, EngineCodes.PostgreSql };
+            var c = Compilers.Compile(engines, query);
+
+            Assert.Equal("SELECT * FROM [mssql]", c[EngineCodes.SqlServer].RawSql);
+            Assert.Equal("SELECT * FROM \"pgsql\"", c[EngineCodes.PostgreSql].RawSql);
+            Assert.Equal("SELECT * FROM `mysql`", c[EngineCodes.MySql].RawSql);
+        }
+
+        [Fact]
+        public void CompilerSpecificFromMixed()
+        {
+            var query = new Query()
+                .ForSqlServer(q => q.From("mssql"))
+                .ForPostgreSql(q => q.FromRaw("[pgsql]"))
+                .ForMySql(q => q.From("mysql"));
+            var engines = new[] { EngineCodes.SqlServer, EngineCodes.MySql, EngineCodes.PostgreSql };
+            var c = Compilers.Compile(engines, query);
+
+            Assert.Equal("SELECT * FROM [mssql]", c[EngineCodes.SqlServer].RawSql);
+            Assert.Equal("SELECT * FROM \"pgsql\"", c[EngineCodes.PostgreSql].RawSql);
+            Assert.Equal("SELECT * FROM `mysql`", c[EngineCodes.MySql].RawSql);
+        }
     }
 }

--- a/QueryBuilder/BaseQuery.cs
+++ b/QueryBuilder/BaseQuery.cs
@@ -83,6 +83,28 @@ namespace SqlKata
         }
 
         /// <summary>
+        /// If the query already contains a clause for the given component
+        /// and engine, replace it with the specified clause. Otherwise, just 
+        /// add the clause.
+        /// </summary>
+        /// <param name="component"></param>
+        /// <param name="clause"></param>
+        /// <param name="engineCode"></param>
+        /// <returns></returns>
+        public Q AddOrReplaceComponent(string component, AbstractClause clause, string engineCode = null)
+        {
+            engineCode = engineCode ?? EngineScope;
+
+            var current = GetComponents(component).SingleOrDefault(c => c.Engine == engineCode);
+            if (current != null)
+                Clauses.Remove(current);
+
+            return AddComponent(component, clause, engineCode);            
+        }
+
+
+
+        /// <summary>
         /// Get the list of clauses for a component.
         /// </summary>
         /// <returns></returns>
@@ -123,13 +145,10 @@ namespace SqlKata
         /// <returns></returns>
         public C GetOneComponent<C>(string component, string engineCode = null) where C : AbstractClause
         {
-            if (engineCode == null)
-            {
-                engineCode = EngineScope;
-            }
+            engineCode = engineCode ?? EngineScope;
 
-            return GetComponents<C>(component, engineCode)
-            .FirstOrDefault();
+            var all = GetComponents<C>(component, engineCode);
+            return all.FirstOrDefault(c => c.Engine == engineCode) ?? all.FirstOrDefault(c => c.Engine == null);
         }
 
         /// <summary>
@@ -149,7 +168,7 @@ namespace SqlKata
         }
 
         /// <summary>
-        /// Return wether the query has clauses for a component.
+        /// Return whether the query has clauses for a component.
         /// </summary>
         /// <param name="component"></param>
         /// <param name="engineCode"></param>
@@ -247,9 +266,9 @@ namespace SqlKata
         /// <returns></returns>
         public Q From(string table)
         {
-            return ClearComponent("from").AddComponent("from", new FromClause
+            return AddOrReplaceComponent("from", new FromClause
             {
-                Table = table
+                Table = table,
             });
         }
 
@@ -263,7 +282,7 @@ namespace SqlKata
                 query.As(alias);
             };
 
-            return ClearComponent("from").AddComponent("from", new QueryFromClause
+            return AddOrReplaceComponent("from", new QueryFromClause
             {
                 Query = query
             });
@@ -271,7 +290,7 @@ namespace SqlKata
 
         public Q FromRaw(string sql, params object[] bindings)
         {
-            return ClearComponent("from").AddComponent("from", new RawFromClause
+            return AddOrReplaceComponent("from", new RawFromClause
             {
                 Expression = sql,
                 Bindings = bindings,

--- a/QueryBuilder/Clauses/FromClause.cs
+++ b/QueryBuilder/Clauses/FromClause.cs
@@ -40,6 +40,7 @@ namespace SqlKata
         {
             return new FromClause
             {
+                Engine = Engine,
                 Alias = Alias,
                 Table = Table,
                 Component = Component,

--- a/QueryBuilder/Clauses/LimitClause.cs
+++ b/QueryBuilder/Clauses/LimitClause.cs
@@ -1,34 +1,13 @@
 namespace SqlKata
 {
-    public class LimitOffset : AbstractClause
+    public class LimitClause : AbstractClause
     {
         private int _limit;
-        private int _offset;
-
+        
         public int Limit
         {
             get => _limit;
-
-            set
-            {
-                if (value > 0)
-                {
-                    _limit = value;
-                }
-            }
-        }
-
-        public int Offset
-        {
-            get => _offset;
-
-            set
-            {
-                if (value > 0)
-                {
-                    _offset = value;
-                }
-            }
+            set => _limit = value > 0 ? value : _limit;
         }
 
         public bool HasLimit()
@@ -36,35 +15,18 @@ namespace SqlKata
             return _limit > 0;
         }
 
-        public bool HasOffset()
-        {
-            return _offset > 0;
-        }
-
-        public LimitOffset ClearLimit()
+        public LimitClause Clear()
         {
             _limit = 0;
             return this;
         }
 
-        public LimitOffset ClearOffset()
-        {
-            _offset = 0;
-            return this;
-        }
-
-        public LimitOffset Clear()
-        {
-            return ClearLimit().ClearOffset();
-        }
-
         /// <inheritdoc />
         public override AbstractClause Clone()
         {
-            return new LimitOffset
+            return new LimitClause
             {
                 Engine = Engine,
-                Offset = Offset,
                 Limit = Limit,
                 Component = Component,
             };

--- a/QueryBuilder/Clauses/OffsetClause.cs
+++ b/QueryBuilder/Clauses/OffsetClause.cs
@@ -1,0 +1,35 @@
+namespace SqlKata
+{
+    public class OffsetClause : AbstractClause
+    {
+        private int _offset;
+
+        public int Offset
+        {
+            get => _offset;
+            set => _offset = value > 0 ? value : _offset;
+        }
+
+        public bool HasOffset()
+        {
+            return _offset > 0;
+        }
+
+        public OffsetClause Clear()
+        {
+            _offset = 0;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public override AbstractClause Clone()
+        {
+            return new OffsetClause
+            {
+                Engine = Engine,
+                Offset = Offset,
+                Component = Component,
+            };
+        }
+    }
+}

--- a/QueryBuilder/Compilers/SqlServerCompiler.cs
+++ b/QueryBuilder/Compilers/SqlServerCompiler.cs
@@ -14,7 +14,7 @@ namespace SqlKata.Compilers
 
         protected override SqlResult CompileSelectQuery(Query query)
         {
-            if (!UseLegacyPagination || !query.HasOffset())
+            if (!UseLegacyPagination || !query.HasOffset(EngineCode))
             {
                 return base.CompileSelectQuery(query);
             }

--- a/QueryBuilder/Query.cs
+++ b/QueryBuilder/Query.cs
@@ -23,36 +23,24 @@ namespace SqlKata
         }
 
 
-        public bool HasOffset(string engineCode = null)
-        {
-            engineCode = engineCode ?? EngineScope;
-            var limitOffset = this.GetOneComponent<LimitOffset>("limit", engineCode);
+        public bool HasOffset(string engineCode = null) => GetOffset(engineCode) > 0;
 
-            return limitOffset?.HasOffset() ?? false;
-        }
-
-        public bool HasLimit(string engineCode = null)
-        {
-            engineCode = engineCode ?? EngineScope;
-            var limitOffset = this.GetOneComponent<LimitOffset>("limit", engineCode);
-
-            return limitOffset?.HasLimit() ?? false;
-        }
+        public bool HasLimit(string engineCode = null) => GetLimit(engineCode) > 0;
 
         internal int GetOffset(string engineCode = null)
         {
             engineCode = engineCode ?? EngineScope;
-            var limitOffset = this.GetOneComponent<LimitOffset>("limit", engineCode);
+            var offset = this.GetOneComponent<OffsetClause>("offset", engineCode);
 
-            return limitOffset?.Offset ?? 0;
+            return offset?.Offset ?? 0;
         }
 
         internal int GetLimit(string engineCode = null)
         {
             engineCode = engineCode ?? EngineScope;
-            var limitOffset = this.GetOneComponent<LimitOffset>("limit", engineCode);
+            var limit = this.GetOneComponent<LimitClause>("limit", engineCode);
 
-            return limitOffset?.Limit ?? 0;
+            return limit?.Limit ?? 0;
         }
 
         public override Query Clone()
@@ -138,28 +126,22 @@ namespace SqlKata
 
         public Query Limit(int value)
         {
-            var newClause = new LimitOffset
+            var newClause = new LimitClause
             {
                 Limit = value
             };
-
-            if (GetOneComponent("limit", EngineScope) is LimitOffset currentClause)
-                newClause.Offset = currentClause.Offset;
 
             return AddOrReplaceComponent("limit", newClause);
         }
 
         public Query Offset(int value)
         {
-            var newClause = new LimitOffset
+            var newClause = new OffsetClause
             {
                 Offset = value
             };
 
-            if (GetOneComponent("limit", EngineScope) is LimitOffset currentClause)
-                newClause.Limit = currentClause.Limit;
-
-            return AddOrReplaceComponent("limit", newClause);
+            return AddOrReplaceComponent("offset", newClause);
         }
 
         /// <summary>

--- a/QueryBuilder/Query.cs
+++ b/QueryBuilder/Query.cs
@@ -25,6 +25,7 @@ namespace SqlKata
 
         public bool HasOffset(string engineCode = null)
         {
+            engineCode = engineCode ?? EngineScope;
             var limitOffset = this.GetOneComponent<LimitOffset>("limit", engineCode);
 
             return limitOffset?.HasOffset() ?? false;
@@ -32,6 +33,7 @@ namespace SqlKata
 
         public bool HasLimit(string engineCode = null)
         {
+            engineCode = engineCode ?? EngineScope;
             var limitOffset = this.GetOneComponent<LimitOffset>("limit", engineCode);
 
             return limitOffset?.HasLimit() ?? false;
@@ -39,6 +41,7 @@ namespace SqlKata
 
         internal int GetOffset(string engineCode = null)
         {
+            engineCode = engineCode ?? EngineScope;
             var limitOffset = this.GetOneComponent<LimitOffset>("limit", engineCode);
 
             return limitOffset?.Offset ?? 0;
@@ -46,6 +49,7 @@ namespace SqlKata
 
         internal int GetLimit(string engineCode = null)
         {
+            engineCode = engineCode ?? EngineScope;
             var limitOffset = this.GetOneComponent<LimitOffset>("limit", engineCode);
 
             return limitOffset?.Limit ?? 0;
@@ -134,34 +138,28 @@ namespace SqlKata
 
         public Query Limit(int value)
         {
-            var clause = GetOneComponent("limit", EngineScope) as LimitOffset;
-
-            if (clause != null)
-            {
-                clause.Limit = value;
-                return this;
-            }
-
-            return AddComponent("limit", new LimitOffset
+            var newClause = new LimitOffset
             {
                 Limit = value
-            });
+            };
+
+            if (GetOneComponent("limit", EngineScope) is LimitOffset currentClause)
+                newClause.Offset = currentClause.Offset;
+
+            return AddOrReplaceComponent("limit", newClause);
         }
 
         public Query Offset(int value)
         {
-            var clause = GetOneComponent("limit", EngineScope) as LimitOffset;
-
-            if (clause != null)
-            {
-                clause.Offset = value;
-                return this;
-            }
-
-            return AddComponent("limit", new LimitOffset
+            var newClause = new LimitOffset
             {
                 Offset = value
-            });
+            };
+
+            if (GetOneComponent("limit", EngineScope) is LimitOffset currentClause)
+                newClause.Limit = currentClause.Limit;
+
+            return AddOrReplaceComponent("limit", newClause);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #239 

Turns out I was right the first time, even though my fork was out of date. If the `Engine` isn't preserved during `FromClause.Clone()`, then 2 of the 3 unit tests I added fail. 