### PR TITLE
Add possibility to call InsertGetId with dictionary parameter

### DIFF
--- a/SqlKata.Execution/Query.Extensions.cs
+++ b/SqlKata.Execution/Query.Extensions.cs
@@ -103,6 +103,15 @@ namespace SqlKata.Execution
 
             return row.Id;
         }
+		
+		public static T InsertGetId<T>(this Query query, IReadOnlyDictionary<string, object> values)
+        {
+            var db = QueryHelper.CreateQueryFactory(query);
+
+            var row = db.First<InsertGetIdRow<T>>(query.AsInsert(values, true));
+
+            return row.Id;
+        }
 
         public static int Update(this Query query, IReadOnlyDictionary<string, object> values)
         {


### PR DESCRIPTION
While Insert method has several overloads: object, dictionary, columns + values, etc,
there is only one overload of InsertGetId - with object.
For my project it very crucial to have possiblity to call InsertGetId with dictionary as a parameter, because I know names of columns only in runtime.
Please, approve it.
