### PR TITLE
Fix `having` clause compilation

### DIFF
--- a/QueryBuilder.Tests/SelectTests.cs
+++ b/QueryBuilder.Tests/SelectTests.cs
@@ -629,5 +629,37 @@ namespace SqlKata.Tests
 
             Assert.Equal("SELECT * FROM \"Table\" WHERE \"MyCol\" = ANY('{1,2,3}'::int[])", c[EngineCodes.PostgreSql]);
         }
+
+        [Fact]
+        public void Having()
+        {
+            var q = new Query("Table1")
+                .Having("Column1", ">", 1);
+            var c = Compile(q);
+
+            Assert.Equal("SELECT * FROM [Table1] HAVING [Column1] > 1", c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
+        public void MultipleHaving()
+        {
+            var q = new Query("Table1")
+                .Having("Column1", ">", 1)
+                .Having("Column2", "=", 1);
+            var c = Compile(q);
+
+            Assert.Equal("SELECT * FROM [Table1] HAVING [Column1] > 1 AND [Column2] = 1", c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
+        public void MultipleOrHaving()
+        {
+            var q = new Query("Table1")
+                .Having("Column1", ">", 1)
+                .OrHaving("Column2", "=", 1);
+            var c = Compile(q);
+
+            Assert.Equal("SELECT * FROM [Table1] HAVING [Column1] > 1 OR [Column2] = 1", c[EngineCodes.SqlServer]);
+        }
     }
 }

--- a/QueryBuilder/Compilers/Compiler.cs
+++ b/QueryBuilder/Compilers/Compiler.cs
@@ -665,11 +665,11 @@ namespace SqlKata.Compilers
                 {
                     boolOperator = i > 0 ? having[i].IsOr ? "OR " : "AND " : "";
 
-                    sql.Add(boolOperator + "HAVING " + compiled);
+                    sql.Add(boolOperator + compiled);
                 }
             }
 
-            return string.Join(", ", sql);
+            return $"HAVING {string.Join(" ", sql)}";
         }
 
         public virtual string CompileLimit(SqlResult ctx)


### PR DESCRIPTION
This PR fixes bad compilation of `having` clause when there is more than one having component. Example:
```
Query:
new Query("Table1").Having("Column1", ">", 1).Having("Column2", "=", 1);

Compiled query:
SELECT * FROM [Table1] HAVING [Column1] > 1, AND HAVING [Column2] = 1
```

With tix fix it would compile to:
`SELECT * FROM [Table1] HAVING [Column1] > 1 AND [Column2] = 1`