### PR TITLE
Avoid SQL Injection in debug SQL

### DIFF
--- a/QueryBuilder/SqlResult.cs
+++ b/QueryBuilder/SqlResult.cs
@@ -81,10 +81,9 @@ namespace SqlKata
             }
 
             // fallback to string
-            return "'" + value.ToString() + "'";
+            return "'" + EscapeSingleQuotes(value.ToString()) + "'";
         }
 
-
-
+        private static string EscapeSingleQuotes(string val) => val.Replace("'", "''");
     }
 }


### PR DESCRIPTION
I was happily making some other contributions to the codebase when I
decided to try testing for SQL Injection vulnerabilities. I was dismayed
when all my single quotes were not escaped in WHERE clauses and nearly
had a panic attack until I realized that the SQL validated in the
majority of these tests is just a debug mashup that includes parameter
bindings.

Nevertheless, I think it makes sense to escape single quotes properly
even in the debug SQL strings, if only to avoid giving some other
hapless maintainer a heart attack.