### PR TITLE
Allow for ad-hoc table CTEs with parameterized data

### DIFF
--- a/QueryBuilder.Tests/GeneralTests.cs
+++ b/QueryBuilder.Tests/GeneralTests.cs
@@ -451,12 +451,12 @@ namespace SqlKata.Tests
 
             var c = Compilers.Compile(query);
 
-            Assert.Equal("WITH [rows] AS (SELECT 1 AS a)\nSELECT * FROM [rows]", c[EngineCodes.SqlServer].ToString());
-            Assert.Equal("WITH \"rows\" AS (SELECT 1 AS a)\nSELECT * FROM \"rows\"", c[EngineCodes.PostgreSql].ToString());
-            Assert.Equal("WITH `rows` AS (SELECT 1 AS a)\nSELECT * FROM `rows`", c[EngineCodes.MySql].ToString());
-            Assert.Equal("WITH \"rows\" AS (SELECT 1 AS a)\nSELECT * FROM \"rows\"", c[EngineCodes.Sqlite].ToString());
-            Assert.Equal("WITH \"ROWS\" AS (SELECT 1 AS a FROM RDB$DATABASE)\nSELECT * FROM \"ROWS\"", c[EngineCodes.Firebird].ToString());
-            Assert.Equal("WITH \"rows\" AS (SELECT 1 AS a FROM DUAL)\nSELECT * FROM \"rows\"", c[EngineCodes.Oracle].ToString());
+            Assert.Equal("WITH [rows] AS (SELECT 1 AS [a])\nSELECT * FROM [rows]", c[EngineCodes.SqlServer].ToString());
+            Assert.Equal("WITH \"rows\" AS (SELECT 1 AS \"a\")\nSELECT * FROM \"rows\"", c[EngineCodes.PostgreSql].ToString());
+            Assert.Equal("WITH `rows` AS (SELECT 1 AS `a`)\nSELECT * FROM `rows`", c[EngineCodes.MySql].ToString());
+            Assert.Equal("WITH \"rows\" AS (SELECT 1 AS \"a\")\nSELECT * FROM \"rows\"", c[EngineCodes.Sqlite].ToString());
+            Assert.Equal("WITH \"ROWS\" AS (SELECT 1 AS \"A\" FROM RDB$DATABASE)\nSELECT * FROM \"ROWS\"", c[EngineCodes.Firebird].ToString());
+            Assert.Equal("WITH \"rows\" AS (SELECT 1 AS \"a\" FROM DUAL)\nSELECT * FROM \"rows\"", c[EngineCodes.Oracle].ToString());
         }
 
         [Fact]
@@ -471,12 +471,12 @@ namespace SqlKata.Tests
 
             var c = Compilers.Compile(query);
 
-            Assert.Equal("WITH [rows] AS (SELECT 1 AS a, 2 AS b, 3 AS c UNION ALL SELECT 4 AS a, 5 AS b, 6 AS c)\nSELECT * FROM [rows]", c[EngineCodes.SqlServer].ToString());
-            Assert.Equal("WITH \"rows\" AS (SELECT 1 AS a, 2 AS b, 3 AS c UNION ALL SELECT 4 AS a, 5 AS b, 6 AS c)\nSELECT * FROM \"rows\"", c[EngineCodes.PostgreSql].ToString());
-            Assert.Equal("WITH `rows` AS (SELECT 1 AS a, 2 AS b, 3 AS c UNION ALL SELECT 4 AS a, 5 AS b, 6 AS c)\nSELECT * FROM `rows`", c[EngineCodes.MySql].ToString());
-            Assert.Equal("WITH \"rows\" AS (SELECT 1 AS a, 2 AS b, 3 AS c UNION ALL SELECT 4 AS a, 5 AS b, 6 AS c)\nSELECT * FROM \"rows\"", c[EngineCodes.Sqlite].ToString());
-            Assert.Equal("WITH \"ROWS\" AS (SELECT 1 AS a, 2 AS b, 3 AS c FROM RDB$DATABASE UNION ALL SELECT 4 AS a, 5 AS b, 6 AS c FROM RDB$DATABASE)\nSELECT * FROM \"ROWS\"", c[EngineCodes.Firebird].ToString());
-            Assert.Equal("WITH \"rows\" AS (SELECT 1 AS a, 2 AS b, 3 AS c FROM DUAL UNION ALL SELECT 4 AS a, 5 AS b, 6 AS c FROM DUAL)\nSELECT * FROM \"rows\"", c[EngineCodes.Oracle].ToString());
+            Assert.Equal("WITH [rows] AS (SELECT 1 AS [a], 2 AS [b], 3 AS [c] UNION ALL SELECT 4 AS [a], 5 AS [b], 6 AS [c])\nSELECT * FROM [rows]", c[EngineCodes.SqlServer].ToString());
+            Assert.Equal("WITH \"rows\" AS (SELECT 1 AS \"a\", 2 AS \"b\", 3 AS \"c\" UNION ALL SELECT 4 AS \"a\", 5 AS \"b\", 6 AS \"c\")\nSELECT * FROM \"rows\"", c[EngineCodes.PostgreSql].ToString());
+            Assert.Equal("WITH `rows` AS (SELECT 1 AS `a`, 2 AS `b`, 3 AS `c` UNION ALL SELECT 4 AS `a`, 5 AS `b`, 6 AS `c`)\nSELECT * FROM `rows`", c[EngineCodes.MySql].ToString());
+            Assert.Equal("WITH \"rows\" AS (SELECT 1 AS \"a\", 2 AS \"b\", 3 AS \"c\" UNION ALL SELECT 4 AS \"a\", 5 AS \"b\", 6 AS \"c\")\nSELECT * FROM \"rows\"", c[EngineCodes.Sqlite].ToString());
+            Assert.Equal("WITH \"ROWS\" AS (SELECT 1 AS \"A\", 2 AS \"B\", 3 AS \"C\" FROM RDB$DATABASE UNION ALL SELECT 4 AS \"A\", 5 AS \"B\", 6 AS \"C\" FROM RDB$DATABASE)\nSELECT * FROM \"ROWS\"", c[EngineCodes.Firebird].ToString());
+            Assert.Equal("WITH \"rows\" AS (SELECT 1 AS \"a\", 2 AS \"b\", 3 AS \"c\" FROM DUAL UNION ALL SELECT 4 AS \"a\", 5 AS \"b\", 6 AS \"c\" FROM DUAL)\nSELECT * FROM \"rows\"", c[EngineCodes.Oracle].ToString());
         }
 
         [Fact]
@@ -497,7 +497,7 @@ namespace SqlKata.Tests
 
             Assert.Equal(string.Join("\n", new[] {
                 "WITH [othercte] AS (SELECT * FROM [othertable] WHERE [othertable].[status] = 'A'),",
-                "[rows] AS (SELECT 1 AS a, 2 AS b, 3 AS c UNION ALL SELECT 4 AS a, 5 AS b, 6 AS c)",
+                "[rows] AS (SELECT 1 AS [a], 2 AS [b], 3 AS [c] UNION ALL SELECT 4 AS [a], 5 AS [b], 6 AS [c])",
                 "SELECT * FROM [rows] WHERE [rows].[foo] = 'bar' AND [rows].[baz] = 'buzz'",
             }), c[EngineCodes.SqlServer].ToString());
         }

--- a/QueryBuilder.Tests/GeneralTests.cs
+++ b/QueryBuilder.Tests/GeneralTests.cs
@@ -451,7 +451,7 @@ namespace SqlKata.Tests
 
             var c = Compilers.Compile(query);
 
-            Assert.Equal("WITH [rows] AS (SELECT 1 AS [a])\nSELECT * FROM [rows]", c[EngineCodes.SqlServer].ToString());
+            Assert.Equal("WITH [rows] AS (SELECT [a] FROM (VALUES (1)) AS tbl ([a]))\nSELECT * FROM [rows]", c[EngineCodes.SqlServer].ToString());
             Assert.Equal("WITH \"rows\" AS (SELECT 1 AS \"a\")\nSELECT * FROM \"rows\"", c[EngineCodes.PostgreSql].ToString());
             Assert.Equal("WITH `rows` AS (SELECT 1 AS `a`)\nSELECT * FROM `rows`", c[EngineCodes.MySql].ToString());
             Assert.Equal("WITH \"rows\" AS (SELECT 1 AS \"a\")\nSELECT * FROM \"rows\"", c[EngineCodes.Sqlite].ToString());
@@ -471,7 +471,7 @@ namespace SqlKata.Tests
 
             var c = Compilers.Compile(query);
 
-            Assert.Equal("WITH [rows] AS (SELECT 1 AS [a], 2 AS [b], 3 AS [c] UNION ALL SELECT 4 AS [a], 5 AS [b], 6 AS [c])\nSELECT * FROM [rows]", c[EngineCodes.SqlServer].ToString());
+            Assert.Equal("WITH [rows] AS (SELECT [a], [b], [c] FROM (VALUES (1, 2, 3), (4, 5, 6)) AS tbl ([a], [b], [c]))\nSELECT * FROM [rows]", c[EngineCodes.SqlServer].ToString());
             Assert.Equal("WITH \"rows\" AS (SELECT 1 AS \"a\", 2 AS \"b\", 3 AS \"c\" UNION ALL SELECT 4 AS \"a\", 5 AS \"b\", 6 AS \"c\")\nSELECT * FROM \"rows\"", c[EngineCodes.PostgreSql].ToString());
             Assert.Equal("WITH `rows` AS (SELECT 1 AS `a`, 2 AS `b`, 3 AS `c` UNION ALL SELECT 4 AS `a`, 5 AS `b`, 6 AS `c`)\nSELECT * FROM `rows`", c[EngineCodes.MySql].ToString());
             Assert.Equal("WITH \"rows\" AS (SELECT 1 AS \"a\", 2 AS \"b\", 3 AS \"c\" UNION ALL SELECT 4 AS \"a\", 5 AS \"b\", 6 AS \"c\")\nSELECT * FROM \"rows\"", c[EngineCodes.Sqlite].ToString());
@@ -497,7 +497,7 @@ namespace SqlKata.Tests
 
             Assert.Equal(string.Join("\n", new[] {
                 "WITH [othercte] AS (SELECT * FROM [othertable] WHERE [othertable].[status] = 'A'),",
-                "[rows] AS (SELECT 1 AS [a], 2 AS [b], 3 AS [c] UNION ALL SELECT 4 AS [a], 5 AS [b], 6 AS [c])",
+                "[rows] AS (SELECT [a], [b], [c] FROM (VALUES (1, 2, 3), (4, 5, 6)) AS tbl ([a], [b], [c]))",
                 "SELECT * FROM [rows] WHERE [rows].[foo] = 'bar' AND [rows].[baz] = 'buzz'",
             }), c[EngineCodes.SqlServer].ToString());
         }

--- a/QueryBuilder/Clauses/FromClause.cs
+++ b/QueryBuilder/Clauses/FromClause.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace SqlKata
 {
@@ -90,6 +91,27 @@ namespace SqlKata
                 Alias = Alias,
                 Expression = Expression,
                 Bindings = Bindings,
+                Component = Component,
+            };
+        }
+    }
+
+    /// <summary>
+    /// Represents a FROM clause that is an ad-hoc table built with predefined values.
+    /// </summary>
+    public class AdHocTableFromClause : AbstractFrom
+    {
+        public List<string> Columns { get; set; }
+        public List<object> Values { get; set; }
+
+        public override AbstractClause Clone()
+        {
+            return new AdHocTableFromClause
+            {
+                Engine = Engine,
+                Alias = Alias,
+                Columns = Columns,
+                Values = Values,
                 Component = Component,
             };
         }

--- a/QueryBuilder/Compilers/Compiler.cs
+++ b/QueryBuilder/Compilers/Compiler.cs
@@ -214,7 +214,7 @@ namespace SqlKata.Compilers
         {
             var ctx = new SqlResult();
 
-            var row = "SELECT " + string.Join(", ", adHoc.Columns.Select(col => $"? AS {WrapIdentifiers(col)}"));
+            var row = "SELECT " + string.Join(", ", adHoc.Columns.Select(col => $"? AS {Wrap(col)}"));
 
             var fromTable = SingleRowDummyTableName;
 

--- a/QueryBuilder/Compilers/FirebirdCompiler.cs
+++ b/QueryBuilder/Compilers/FirebirdCompiler.cs
@@ -11,6 +11,7 @@ namespace SqlKata.Compilers
         }
 
         public override string EngineCode { get; } = EngineCodes.Firebird;
+        protected override string SingleRowDummyTableName => "RDB$DATABASE";
 
         protected override SqlResult CompileInsertQuery(Query query)
         {

--- a/QueryBuilder/Compilers/OracleCompiler.cs
+++ b/QueryBuilder/Compilers/OracleCompiler.cs
@@ -16,6 +16,7 @@ namespace SqlKata.Compilers
 
         public override string EngineCode { get; } = EngineCodes.Oracle;
         public bool UseLegacyPagination { get; set; } = false;
+        protected override string SingleRowDummyTableName => "DUAL";
 
         protected override SqlResult CompileSelectQuery(Query query)
         {

--- a/QueryBuilder/Compilers/SqlServerCompiler.cs
+++ b/QueryBuilder/Compilers/SqlServerCompiler.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 namespace SqlKata.Compilers
 {
     public class SqlServerCompiler : Compiler
@@ -167,6 +169,22 @@ namespace SqlKata.Compilers
             }
 
             return sql;
+        }
+
+        protected override SqlResult CompileAdHocQuery(AdHocTableFromClause adHoc)
+        {
+            var ctx = new SqlResult();
+
+            var colNames = string.Join(", ", adHoc.Columns.Select(Wrap));
+
+            var valueRow = string.Join(", ", Enumerable.Repeat("?", adHoc.Columns.Count));
+            var valueRows = string.Join(", ", Enumerable.Repeat($"({valueRow})", adHoc.Values.Count / adHoc.Columns.Count));
+            var sql = $"SELECT {colNames} FROM (VALUES {valueRows}) AS tbl ({colNames})";
+
+            ctx.RawSql = sql;
+            ctx.Bindings = adHoc.Values;
+
+            return ctx;
         }
     }
 }

--- a/QueryBuilder/Query.cs
+++ b/QueryBuilder/Query.cs
@@ -118,6 +118,40 @@ namespace SqlKata
             return With(alias, fn.Invoke(new Query()));
         }
 
+        /// <summary>
+        /// Constructs an ad-hoc table of the given data as a CTE.
+        /// </summary>
+        public Query With(string alias, IEnumerable<string> columns, IEnumerable<IEnumerable<object>> valuesCollection)
+        {
+            var columnsList = columns?.ToList();
+            var valuesCollectionList = valuesCollection?.ToList();
+
+            if ((columnsList?.Count ?? 0) == 0 || (valuesCollectionList?.Count ?? 0) == 0)
+            {
+                throw new InvalidOperationException("Columns and valuesCollection cannot be null or empty");
+            }
+
+            var clause = new AdHocTableFromClause()
+            {
+                Alias = alias,
+                Columns = columnsList,
+                Values = new List<object>(),
+            };
+
+            foreach (var values in valuesCollectionList)
+            {
+                var valuesList = values.ToList();
+                if (columnsList.Count != valuesList.Count)
+                {
+                    throw new InvalidOperationException("Columns count should be equal to each Values count");
+                }
+
+                clause.Values.AddRange(valuesList);
+            }
+
+            return AddComponent("cte", clause);
+        }
+
         public Query WithRaw(string alias, string sql, params object[] bindings)
         {
             return AddComponent("cte", new RawFromClause


### PR DESCRIPTION
This addresses the request in #152 by adding a `With(...)` variation that takes a list of column names and a list of list of values to create a CTE representation of that data. That CTE can then be used in subsequent SELECT statements to, for example, query efficiently against a number of composite keys.

Here is an example for creating a CTE with two rows of parameterized data:

```c#
var query = new Query("rows").With("rows",
    new[] { "a", "b", "c" },
    new object[][] {
        new object[] { 1, 2, 3 },
        new object[] { 4, 5, 6 },
    });
```

This conceptually results in a CTE whose contents are:

a | b | c
-- | -- | --
1 | 2 | 3
4 | 5 | 6

The default SQL implementation uses a number of `SELECT` statements joined by `UNION ALL`:

Postgres Output:

```sql
WITH "rows" AS (
    SELECT 1 AS "a", 2 AS "b", 3 AS "c"
    UNION ALL
    SELECT 4 AS "a", 5 AS "b", 6 AS "c"
)
SELECT *
FROM "rows"
```

SQL Server output uses its own `VALUES (...), (...)` syntax:

```sql
WITH [rows] AS (
    SELECT [a], [b], [c]
    FROM (
        VALUES
            (1, 2, 3),
            (4, 5, 6)
    ) AS tbl ([a], [b], [c])
)
SELECT *
FROM [rows]
```

_Note: The initial issue #152 showed that Postgres has its own syntax for ad-hoc tables in a CTE, but I did not implement that specific flavor because it would involve more substantial changes to the actual `WITH` portion of the CTE, e.g. `WITH cte (a, b, c) AS (...)`. Postgres instead uses the `UNION ALL` flavor_