### PR TITLE
Adding Escape clause to LIKE operator conditions - related to #237

### DIFF
--- a/QueryBuilder.Tests/SelectTests.cs
+++ b/QueryBuilder.Tests/SelectTests.cs
@@ -1,6 +1,7 @@
 ﻿using SqlKata.Compilers;
 using SqlKata.Extensions;
 using SqlKata.Tests.Infrastructure;
+using System;
 using Xunit;
 
 namespace SqlKata.Tests
@@ -697,6 +698,96 @@ namespace SqlKata.Tests
             var c = Compile(q);
 
             Assert.Equal("SELECT * FROM [Table1] HAVING [Column1] > 1 OR [Column2] = 1", c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
+        public void EscapedWhereLike()
+        {
+            var q = new Query("Table1")
+                .WhereLike("Column1", @"TestString\%", false, @"\");
+            var c = Compile(q);
+
+            Assert.Equal(@"SELECT * FROM [Table1] WHERE LOWER([Column1]) like 'teststring\%' ESCAPE '\'", c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
+        public void EscapedWhereStarts()
+        {
+            var q = new Query("Table1")
+                .WhereStarts("Column1", @"TestString\%", false, @"\");
+            var c = Compile(q);
+
+            Assert.Equal(@"SELECT * FROM [Table1] WHERE LOWER([Column1]) like 'teststring\%%' ESCAPE '\'", c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
+        public void EscapedWhereEnds()
+        {
+            var q = new Query("Table1")
+                .WhereEnds("Column1", @"TestString\%", false, @"\");
+            var c = Compile(q);
+
+            Assert.Equal(@"SELECT * FROM [Table1] WHERE LOWER([Column1]) like '%teststring\%' ESCAPE '\'", c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
+        public void EscapedWhereContains()
+        {
+            var q = new Query("Table1")
+                .WhereContains("Column1", @"TestString\%", false, @"\");
+            var c = Compile(q);
+
+            Assert.Equal(@"SELECT * FROM [Table1] WHERE LOWER([Column1]) like '%teststring\%%' ESCAPE '\'", c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
+        public void EscapedHavingLike()
+        {
+            var q = new Query("Table1")
+                .HavingLike("Column1", @"TestString\%", false, @"\");
+            var c = Compile(q);
+
+            Assert.Equal(@"SELECT * FROM [Table1] HAVING LOWER([Column1]) like 'teststring\%' ESCAPE '\'", c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
+        public void EscapedHavingStarts()
+        {
+            var q = new Query("Table1")
+                .HavingStarts("Column1", @"TestString\%", false, @"\");
+            var c = Compile(q);
+
+            Assert.Equal(@"SELECT * FROM [Table1] HAVING LOWER([Column1]) like 'teststring\%%' ESCAPE '\'", c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
+        public void EscapedHavingEnds()
+        {
+            var q = new Query("Table1")
+                .HavingEnds("Column1", @"TestString\%", false, @"\");
+            var c = Compile(q);
+
+            Assert.Equal(@"SELECT * FROM [Table1] HAVING LOWER([Column1]) like '%teststring\%' ESCAPE '\'", c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
+        public void EscapedHavingContains()
+        {
+            var q = new Query("Table1")
+                .HavingContains("Column1", @"TestString\%", false, @"\");
+            var c = Compile(q);
+
+            Assert.Equal(@"SELECT * FROM [Table1] HAVING LOWER([Column1]) like '%teststring\%%' ESCAPE '\'", c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
+        public void EscapeClauseThrowsForMultipleCharacters()
+        {
+            Assert.ThrowsAny<ArgumentException>(() =>
+            {
+                var q = new Query("Table1")
+                    .HavingContains("Column1", @"TestString\%", false, @"\aa");
+            });
         }
     }
 }

--- a/QueryBuilder/Base.Where.cs
+++ b/QueryBuilder/Base.Where.cs
@@ -228,7 +228,7 @@ namespace SqlKata
             return Or().WhereFalse(column);
         }
 
-        public Q WhereLike(string column, object value, bool caseSensitive = false)
+        public Q WhereLike(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
             return AddComponent("where", new BasicStringCondition
             {
@@ -236,26 +236,27 @@ namespace SqlKata
                 Column = column,
                 Value = value,
                 CaseSensitive = caseSensitive,
+                EscapeCharacter = escapeCharacter,
                 IsOr = GetOr(),
                 IsNot = GetNot(),
             });
         }
 
-        public Q WhereNotLike(string column, object value, bool caseSensitive = false)
+        public Q WhereNotLike(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
-            return Not().WhereLike(column, value, caseSensitive);
+            return Not().WhereLike(column, value, caseSensitive, escapeCharacter);
         }
 
-        public Q OrWhereLike(string column, object value, bool caseSensitive = false)
+        public Q OrWhereLike(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
-            return Or().WhereLike(column, value, caseSensitive);
+            return Or().WhereLike(column, value, caseSensitive, escapeCharacter);
         }
 
-        public Q OrWhereNotLike(string column, object value, bool caseSensitive = false)
+        public Q OrWhereNotLike(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
-            return Or().Not().WhereLike(column, value, caseSensitive);
+            return Or().Not().WhereLike(column, value, caseSensitive, escapeCharacter);
         }
-        public Q WhereStarts(string column, object value, bool caseSensitive = false)
+        public Q WhereStarts(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
             return AddComponent("where", new BasicStringCondition
             {
@@ -263,27 +264,28 @@ namespace SqlKata
                 Column = column,
                 Value = value,
                 CaseSensitive = caseSensitive,
+                EscapeCharacter = escapeCharacter,
                 IsOr = GetOr(),
                 IsNot = GetNot(),
             });
         }
 
-        public Q WhereNotStarts(string column, object value, bool caseSensitive = false)
+        public Q WhereNotStarts(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
-            return Not().WhereStarts(column, value, caseSensitive);
+            return Not().WhereStarts(column, value, caseSensitive, escapeCharacter);
         }
 
-        public Q OrWhereStarts(string column, object value, bool caseSensitive = false)
+        public Q OrWhereStarts(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
-            return Or().WhereStarts(column, value, caseSensitive);
+            return Or().WhereStarts(column, value, caseSensitive, escapeCharacter);
         }
 
-        public Q OrWhereNotStarts(string column, object value, bool caseSensitive = false)
+        public Q OrWhereNotStarts(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
-            return Or().Not().WhereStarts(column, value, caseSensitive);
+            return Or().Not().WhereStarts(column, value, caseSensitive, escapeCharacter);
         }
 
-        public Q WhereEnds(string column, object value, bool caseSensitive = false)
+        public Q WhereEnds(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
             return AddComponent("where", new BasicStringCondition
             {
@@ -291,27 +293,28 @@ namespace SqlKata
                 Column = column,
                 Value = value,
                 CaseSensitive = caseSensitive,
+                EscapeCharacter = escapeCharacter,
                 IsOr = GetOr(),
                 IsNot = GetNot(),
             });
         }
 
-        public Q WhereNotEnds(string column, object value, bool caseSensitive = false)
+        public Q WhereNotEnds(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
-            return Not().WhereEnds(column, value, caseSensitive);
+            return Not().WhereEnds(column, value, caseSensitive, escapeCharacter);
         }
 
-        public Q OrWhereEnds(string column, object value, bool caseSensitive = false)
+        public Q OrWhereEnds(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
-            return Or().WhereEnds(column, value, caseSensitive);
+            return Or().WhereEnds(column, value, caseSensitive, escapeCharacter);
         }
 
-        public Q OrWhereNotEnds(string column, object value, bool caseSensitive = false)
+        public Q OrWhereNotEnds(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
-            return Or().Not().WhereEnds(column, value, caseSensitive);
+            return Or().Not().WhereEnds(column, value, caseSensitive, escapeCharacter);
         }
 
-        public Q WhereContains(string column, object value, bool caseSensitive = false)
+        public Q WhereContains(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
             return AddComponent("where", new BasicStringCondition
             {
@@ -319,24 +322,25 @@ namespace SqlKata
                 Column = column,
                 Value = value,
                 CaseSensitive = caseSensitive,
+                EscapeCharacter = escapeCharacter,
                 IsOr = GetOr(),
                 IsNot = GetNot(),
             });
         }
 
-        public Q WhereNotContains(string column, object value, bool caseSensitive = false)
+        public Q WhereNotContains(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
-            return Not().WhereContains(column, value, caseSensitive);
+            return Not().WhereContains(column, value, caseSensitive, escapeCharacter);
         }
 
-        public Q OrWhereContains(string column, object value, bool caseSensitive = false)
+        public Q OrWhereContains(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
-            return Or().WhereContains(column, value, caseSensitive);
+            return Or().WhereContains(column, value, caseSensitive, escapeCharacter);
         }
 
-        public Q OrWhereNotContains(string column, object value, bool caseSensitive = false)
+        public Q OrWhereNotContains(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
-            return Or().Not().WhereContains(column, value, caseSensitive);
+            return Or().Not().WhereContains(column, value, caseSensitive, escapeCharacter);
         }
 
         public Q WhereBetween<T>(string column, T lower, T higher)

--- a/QueryBuilder/Clauses/ConditionClause.cs
+++ b/QueryBuilder/Clauses/ConditionClause.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace SqlKata
@@ -35,8 +36,22 @@ namespace SqlKata
 
     public class BasicStringCondition : BasicCondition
     {
+
         public bool CaseSensitive { get; set; } = false;
 
+        private string escapeCharacter = null;
+        public string EscapeCharacter
+        {
+            get => escapeCharacter;
+            set
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                    value = null;
+                else if (value.Length > 1)
+                    throw new ArgumentOutOfRangeException("The EscapeCharacter can only contain a single character!");
+                escapeCharacter = value;
+            }
+        }
         /// <inheritdoc />
         public override AbstractClause Clone()
         {
@@ -49,6 +64,7 @@ namespace SqlKata
                 IsOr = IsOr,
                 IsNot = IsNot,
                 CaseSensitive = CaseSensitive,
+                EscapeCharacter = EscapeCharacter,
                 Component = Component,
             };
         }

--- a/QueryBuilder/Compilers/Compiler.Conditions.cs
+++ b/QueryBuilder/Compilers/Compiler.Conditions.cs
@@ -117,17 +117,17 @@ namespace SqlKata.Compilers
 
                 method = "LIKE";
 
-                if (x.Operator == "starts")
+                switch (x.Operator)
                 {
-                    value = $"{value}%";
-                }
-                else if (x.Operator == "ends")
-                {
-                    value = $"%{value}";
-                }
-                else if (x.Operator == "contains")
-                {
-                    value = $"%{value}%";
+                    case "starts":
+                        value = $"{value}%";
+                        break;
+                    case "ends":
+                        value = $"%{value}";
+                        break;
+                    case "contains":
+                        value = $"%{value}%";
+                        break;
                 }
             }
 
@@ -147,6 +147,11 @@ namespace SqlKata.Compilers
             else
             {
                 sql = $"{column} {checkOperator(method)} {Parameter(ctx, value)}";
+            }
+
+            if (!string.IsNullOrEmpty(x.EscapeCharacter))
+            {
+                sql = $"{sql} ESCAPE '{x.EscapeCharacter}'";
             }
 
             return x.IsNot ? $"NOT ({sql})" : sql;

--- a/QueryBuilder/Query.Having.cs
+++ b/QueryBuilder/Query.Having.cs
@@ -218,7 +218,7 @@ namespace SqlKata
             return Or().HavingFalse(column);
         }
 
-        public Query HavingLike(string column, object value, bool caseSensitive = false)
+        public Query HavingLike(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
             return AddComponent("having", new BasicStringCondition
             {
@@ -226,26 +226,27 @@ namespace SqlKata
                 Column = column,
                 Value = value,
                 CaseSensitive = caseSensitive,
+                EscapeCharacter = escapeCharacter,
                 IsOr = GetOr(),
                 IsNot = GetNot(),
             });
         }
 
-        public Query HavingNotLike(string column, object value, bool caseSensitive = false)
+        public Query HavingNotLike(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
-            return Not().HavingLike(column, value, caseSensitive);
+            return Not().HavingLike(column, value, caseSensitive, escapeCharacter);
         }
 
-        public Query OrHavingLike(string column, object value, bool caseSensitive = false)
+        public Query OrHavingLike(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
-            return Or().HavingLike(column, value, caseSensitive);
+            return Or().HavingLike(column, value, caseSensitive, escapeCharacter);
         }
 
-        public Query OrHavingNotLike(string column, object value, bool caseSensitive = false)
+        public Query OrHavingNotLike(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
-            return Or().Not().HavingLike(column, value, caseSensitive);
+            return Or().Not().HavingLike(column, value, caseSensitive, escapeCharacter);
         }
-        public Query HavingStarts(string column, object value, bool caseSensitive = false)
+        public Query HavingStarts(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
             return AddComponent("having", new BasicStringCondition
             {
@@ -253,27 +254,28 @@ namespace SqlKata
                 Column = column,
                 Value = value,
                 CaseSensitive = caseSensitive,
+                EscapeCharacter = escapeCharacter,
                 IsOr = GetOr(),
                 IsNot = GetNot(),
             });
         }
 
-        public Query HavingNotStarts(string column, object value, bool caseSensitive = false)
+        public Query HavingNotStarts(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
-            return Not().HavingStarts(column, value, caseSensitive);
+            return Not().HavingStarts(column, value, caseSensitive, escapeCharacter);
         }
 
-        public Query OrHavingStarts(string column, object value, bool caseSensitive = false)
+        public Query OrHavingStarts(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
-            return Or().HavingStarts(column, value, caseSensitive);
+            return Or().HavingStarts(column, value, caseSensitive, escapeCharacter);
         }
 
-        public Query OrHavingNotStarts(string column, object value, bool caseSensitive = false)
+        public Query OrHavingNotStarts(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
-            return Or().Not().HavingStarts(column, value, caseSensitive);
+            return Or().Not().HavingStarts(column, value, caseSensitive, escapeCharacter);
         }
 
-        public Query HavingEnds(string column, object value, bool caseSensitive = false)
+        public Query HavingEnds(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
             return AddComponent("having", new BasicStringCondition
             {
@@ -281,27 +283,28 @@ namespace SqlKata
                 Column = column,
                 Value = value,
                 CaseSensitive = caseSensitive,
+                EscapeCharacter = escapeCharacter,
                 IsOr = GetOr(),
                 IsNot = GetNot(),
             });
         }
 
-        public Query HavingNotEnds(string column, object value, bool caseSensitive = false)
+        public Query HavingNotEnds(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
-            return Not().HavingEnds(column, value, caseSensitive);
+            return Not().HavingEnds(column, value, caseSensitive, escapeCharacter);
         }
 
-        public Query OrHavingEnds(string column, object value, bool caseSensitive = false)
+        public Query OrHavingEnds(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
-            return Or().HavingEnds(column, value, caseSensitive);
+            return Or().HavingEnds(column, value, caseSensitive, escapeCharacter);
         }
 
-        public Query OrHavingNotEnds(string column, object value, bool caseSensitive = false)
+        public Query OrHavingNotEnds(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
-            return Or().Not().HavingEnds(column, value, caseSensitive);
+            return Or().Not().HavingEnds(column, value, caseSensitive, escapeCharacter);
         }
 
-        public Query HavingContains(string column, object value, bool caseSensitive = false)
+        public Query HavingContains(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
             return AddComponent("having", new BasicStringCondition
             {
@@ -309,24 +312,25 @@ namespace SqlKata
                 Column = column,
                 Value = value,
                 CaseSensitive = caseSensitive,
+                EscapeCharacter = escapeCharacter,
                 IsOr = GetOr(),
                 IsNot = GetNot(),
             });
         }
 
-        public Query HavingNotContains(string column, object value, bool caseSensitive = false)
+        public Query HavingNotContains(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
-            return Not().HavingContains(column, value, caseSensitive);
+            return Not().HavingContains(column, value, caseSensitive, escapeCharacter);
         }
 
-        public Query OrHavingContains(string column, object value, bool caseSensitive = false)
+        public Query OrHavingContains(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
-            return Or().HavingContains(column, value, caseSensitive);
+            return Or().HavingContains(column, value, caseSensitive, escapeCharacter);
         }
 
-        public Query OrHavingNotContains(string column, object value, bool caseSensitive = false)
+        public Query OrHavingNotContains(string column, object value, bool caseSensitive = false, string escapeCharacter = null)
         {
-            return Or().Not().HavingContains(column, value, caseSensitive);
+            return Or().Not().HavingContains(column, value, caseSensitive, escapeCharacter);
         }
 
         public Query HavingBetween<T>(string column, T lower, T higher)


### PR DESCRIPTION
As discussed in the issue I created the implementation I had in mind, added a number of tests and it seems to work fine, other tests didn't fail as a result of the addition.