### PR TITLE
Resolution for sqlkata/querybuilder#33

### DIFF
--- a/SqlKata.Execution/Query.Extensions.Async.cs
+++ b/SqlKata.Execution/Query.Extensions.Async.cs
@@ -92,6 +92,14 @@ namespace SqlKata.Execution
             return row.Id;
         }
 
+        public static async Task<T> InsertGetIdAsync<T>(this Query query, IReadOnlyDictionary<string, object> data)
+        {
+            var row = await QueryHelper.CreateQueryFactory(query)
+                .FirstAsync<InsertGetIdRow<T>>(query.AsInsert(data, true));
+
+            return row.Id;
+        }
+
         public static async Task<int> InsertAsync(
             this Query query,
             IEnumerable<string> columns,


### PR DESCRIPTION
 Added a new extension for InsertGetIdAsync which takes a ReadOnlyDictionary.  Resolves the issue with "Parameter count mismatch"