### PR TITLE
Race condition fix for ConditionsCompilerProvider dictionary access

### DIFF
--- a/QueryBuilder/Compilers/ConditionsCompilerProvider.cs
+++ b/QueryBuilder/Compilers/ConditionsCompilerProvider.cs
@@ -21,11 +21,6 @@ namespace SqlKata.Compilers
             // The cache key should take the type and the method name into consideration
             var cacheKey = methodName + "::" + clauseType.FullName;
 
-            if (methodsCache.ContainsKey(cacheKey))
-            {
-                return methodsCache[cacheKey];
-            }
-
             lock (syncRoot)
             {
                 if (methodsCache.ContainsKey(cacheKey))


### PR DESCRIPTION
Avoids a possible NullReferenceException when checking for the existence of a key in a non-thread-safe dictionary.

Although the dictionary is only written to inside the `lock`, accessing it outside the lock while any number of other threads are potentially writing to it can cause a NullPointerException (eg: if the internal buckets are being resized, or are half-way through being written to).

Reads need to happen inside the lock, which can be solved by simply removing the 3 lines as shown here. (You could also achieve the same thing by using a ConcurrentDictionary instead and the GetOrAdd method to specify how to populate the entry when it's missing)

You can trigger this bug fairly easily by setting up a few threads which all call `ConditionsCompilerProvider::GetMethodInfo` in parallel with the same type/method name values.  I didn't add a test to the tests project, as it's not a deterministic thing, but I can send you some sample code to trigger it if you like.