### PR TITLE
Allow returning columns in Insert / Update clauses

### DIFF
--- a/QueryBuilder.Tests/UpdateTests.cs
+++ b/QueryBuilder.Tests/UpdateTests.cs
@@ -26,6 +26,48 @@ namespace SqlKata.Tests
         }
 
         [Fact]
+        public void UpdateReturning()
+        {
+            var query = new Query("Table").AsUpdate(new
+            {
+                Name = "The User",
+                Age = new DateTime(2018, 1, 1),
+            }, new [] { "Name", "Age" });
+
+            var c = Compile(query);
+
+            Assert.Equal("UPDATE \"Table\" SET \"Name\" = 'The User', \"Age\" = '2018-01-01' RETURNING \"Name\", \"Age\"", c[EngineCodes.PostgreSql]);
+        }
+
+        [Fact]
+        public void UpdateReturningNull()
+        {
+            var query = new Query("Table").AsUpdate(new
+            {
+                Name = "The User",
+                Age = new DateTime(2018, 1, 1),
+            },  null);
+
+            var c = Compile(query);
+
+            Assert.Equal("UPDATE \"Table\" SET \"Name\" = 'The User', \"Age\" = '2018-01-01'", c[EngineCodes.PostgreSql]);
+        }
+
+        [Fact]
+        public void UpdateReturningAll()
+        {
+            var query = new Query("Table").AsUpdate(new
+            {
+                Name = "The User",
+                Age = new DateTime(2018, 1, 1),
+            }, new [] { "*" });
+
+            var c = Compile(query);
+
+            Assert.Equal("UPDATE \"Table\" SET \"Name\" = 'The User', \"Age\" = '2018-01-01' RETURNING *", c[EngineCodes.PostgreSql]);
+        }
+
+        [Fact]
         public void UpdateWithNullValues()
         {
             var query = new Query("Books").Where("Id", 1).AsUpdate(

--- a/QueryBuilder/Clauses/InsertClause.cs
+++ b/QueryBuilder/Clauses/InsertClause.cs
@@ -12,6 +12,7 @@ namespace SqlKata
         public List<string> Columns { get; set; }
         public List<object> Values { get; set; }
         public bool ReturnId { get; set; } = false;
+        public List<string> ReturnColumns { get; set; } = new List<string>();
 
         public override AbstractClause Clone()
         {
@@ -22,6 +23,7 @@ namespace SqlKata
                 Columns = Columns,
                 Values = Values,
                 ReturnId = ReturnId,
+                ReturnColumns = ReturnColumns,
             };
         }
     }

--- a/QueryBuilder/Compilers/Compiler.cs
+++ b/QueryBuilder/Compilers/Compiler.cs
@@ -346,6 +346,7 @@ namespace SqlKata.Compilers
             }
 
             var inserts = ctx.Query.GetComponents<AbstractInsertClause>("insert", EngineCode);
+            var returningColumns = inserts.Where(clause => (clause as InsertClause)?.ReturnColumns != null).SelectMany(clause => (clause as InsertClause).ReturnColumns).Distinct().ToList();
 
             if (inserts[0] is InsertClause insertClause)
             {
@@ -387,6 +388,11 @@ namespace SqlKata.Compilers
                 }
             }
 
+            if (returningColumns.Count > 0)
+            {
+                var returnColumns = string.Join(", ", WrapArray(returningColumns));
+                ctx.RawSql += $" RETURNING {returnColumns}";
+            }
 
             return ctx;
         }

--- a/QueryBuilder/Compilers/Compiler.cs
+++ b/QueryBuilder/Compilers/Compiler.cs
@@ -305,6 +305,11 @@ namespace SqlKata.Compilers
 
             ctx.RawSql = $"UPDATE {table} SET {sets}{where}";
 
+            if (toUpdate.ReturnColumns != null) {
+                var returnColumns = string.Join(", ", WrapArray(toUpdate.ReturnColumns));
+                ctx.RawSql += $" RETURNING {returnColumns}";
+            }
+
             return ctx;
         }
 

--- a/QueryBuilder/Query.Insert.cs
+++ b/QueryBuilder/Query.Insert.cs
@@ -7,11 +7,16 @@ namespace SqlKata
 {
     public partial class Query
     {
-        public Query AsInsert(object data, bool returnId = false)
+        public Query AsInsert(object data, bool returnId = false, IEnumerable<string> returnColumns = null)
         {
             var dictionary = BuildDictionaryFromObject(data);
 
-            return AsInsert(dictionary, returnId);
+            return AsInsert(dictionary, returnId, returnColumns);
+        }
+
+        public Query AsInsert(object data, IEnumerable<string> returnColumns)
+        {
+            return AsInsert(data, false, returnColumns);
         }
 
         public Query AsInsert(IEnumerable<string> columns, IEnumerable<object> values)
@@ -40,7 +45,7 @@ namespace SqlKata
             return this;
         }
 
-        public Query AsInsert(IReadOnlyDictionary<string, object> data, bool returnId = false)
+        public Query AsInsert(IReadOnlyDictionary<string, object> data, bool returnId = false, IEnumerable<string> returnColumns = null)
         {
             if (data == null || data.Count == 0)
             {
@@ -54,9 +59,15 @@ namespace SqlKata
                 Columns = data.Keys.ToList(),
                 Values = data.Values.ToList(),
                 ReturnId = returnId,
+                ReturnColumns = returnColumns?.ToList(),
             });
 
             return this;
+        }
+
+        public Query AsInsert(IReadOnlyDictionary<string, object> data, IEnumerable<string> returnColumns)
+        {
+            return AsInsert(data, false, returnColumns);
         }
 
         /// <summary>
@@ -64,11 +75,13 @@ namespace SqlKata
         /// </summary>
         /// <param name="columns"></param>
         /// <param name="valuesCollection"></param>
+        /// <param name="returnColumns"></param>
         /// <returns></returns>
-        public Query AsInsert(IEnumerable<string> columns, IEnumerable<IEnumerable<object>> valuesCollection)
+        public Query AsInsert(IEnumerable<string> columns, IEnumerable<IEnumerable<object>> valuesCollection, IEnumerable<string> returnColumns = null)
         {
             var columnsList = columns?.ToList();
             var valuesCollectionList = valuesCollection?.ToList();
+            var returnColumnsList = returnColumns?.ToList();
 
             if ((columnsList?.Count ?? 0) == 0 || (valuesCollectionList?.Count ?? 0) == 0)
             {
@@ -90,7 +103,8 @@ namespace SqlKata
                 AddComponent("insert", new InsertClause
                 {
                     Columns = columnsList,
-                    Values = valuesList
+                    Values = valuesList,
+                    ReturnColumns = returnColumnsList,
                 });
             }
 

--- a/QueryBuilder/Query.Update.cs
+++ b/QueryBuilder/Query.Update.cs
@@ -9,14 +9,14 @@ namespace SqlKata
     public partial class Query
     {
 
-        public Query AsUpdate(object data)
+        public Query AsUpdate(object data, IEnumerable<string> returnColumns = null)
         {
             var dictionary = BuildDictionaryFromObject(data, considerKeys: true);
 
-            return AsUpdate(dictionary);
+            return AsUpdate(dictionary, returnColumns);
         }
 
-        public Query AsUpdate(IEnumerable<string> columns, IEnumerable<object> values)
+        public Query AsUpdate(IEnumerable<string> columns, IEnumerable<object> values, IEnumerable<string> returnColumns = null)
         {
 
             if ((columns?.Count() ?? 0) == 0 || (values?.Count() ?? 0) == 0)
@@ -34,13 +34,14 @@ namespace SqlKata
             ClearComponent("update").AddComponent("update", new InsertClause
             {
                 Columns = columns.ToList(),
-                Values = values.ToList()
+                Values = values.ToList(),
+                ReturnColumns = returnColumns?.ToList(),
             });
 
             return this;
         }
 
-        public Query AsUpdate(IReadOnlyDictionary<string, object> data)
+        public Query AsUpdate(IReadOnlyDictionary<string, object> data, IEnumerable<string> returnColumns = null)
         {
 
             if (data == null || data.Count == 0)
@@ -54,6 +55,7 @@ namespace SqlKata
             {
                 Columns = data.Keys.ToList(),
                 Values = data.Values.ToList(),
+                ReturnColumns = returnColumns?.ToList(),
             });
 
             return this;

--- a/SqlKata.Execution/Query.Extensions.Async.cs
+++ b/SqlKata.Execution/Query.Extensions.Async.cs
@@ -71,17 +71,18 @@ namespace SqlKata.Execution
 
         public static async Task<int> InsertAsync(
             this Query query,
-            IReadOnlyDictionary<string, object> values
+            IReadOnlyDictionary<string, object> values,
+            IEnumerable<string> returnColumns = null
         )
         {
             return await QueryHelper.CreateQueryFactory(query)
-                .ExecuteAsync(query.AsInsert(values));
+                .ExecuteAsync(query.AsInsert(values, returnColumns));
         }
 
-        public static async Task<int> InsertAsync(this Query query, object data)
+        public static async Task<int> InsertAsync(this Query query, object data, IEnumerable<string> returnColumns = null)
         {
             return await QueryHelper.CreateQueryFactory(query)
-                .ExecuteAsync(query.AsInsert(data));
+                .ExecuteAsync(query.AsInsert(data, returnColumns));
         }
 
         public static async Task<T> InsertGetIdAsync<T>(this Query query, object data)

--- a/SqlKata.Execution/Query.Extensions.Async.cs
+++ b/SqlKata.Execution/Query.Extensions.Async.cs
@@ -111,16 +111,16 @@ namespace SqlKata.Execution
                 .ExecuteAsync(query.AsInsert(columns, fromQuery));
         }
 
-        public static async Task<int> UpdateAsync(this Query query, IReadOnlyDictionary<string, object> values)
+        public static async Task<int> UpdateAsync(this Query query, IReadOnlyDictionary<string, object> values, IEnumerable<string> returnColumns = null)
         {
             return await QueryHelper.CreateQueryFactory(query)
-                .ExecuteAsync(query.AsUpdate(values));
+                .ExecuteAsync(query.AsUpdate(values, returnColumns));
         }
 
-        public static async Task<int> UpdateAsync(this Query query, object data)
+        public static async Task<int> UpdateAsync(this Query query, object data, IEnumerable<string> returnColumns = null)
         {
             return await QueryHelper.CreateQueryFactory(query)
-                .ExecuteAsync(query.AsUpdate(data));
+                .ExecuteAsync(query.AsUpdate(data, returnColumns));
         }
 
         public static async Task<int> DeleteAsync(this Query query)

--- a/SqlKata.Execution/Query.Extensions.cs
+++ b/SqlKata.Execution/Query.Extensions.cs
@@ -105,14 +105,14 @@ namespace SqlKata.Execution
             return row.Id;
         }
 
-        public static int Update(this Query query, IReadOnlyDictionary<string, object> values)
+        public static int Update(this Query query, IReadOnlyDictionary<string, object> values, IEnumerable<string> returnColumns = null)
         {
-            return QueryHelper.CreateQueryFactory(query).Execute(query.AsUpdate(values));
+            return QueryHelper.CreateQueryFactory(query).Execute(query.AsUpdate(values, returnColumns));
         }
 
-        public static int Update(this Query query, object data)
+        public static int Update(this Query query, object data, IEnumerable<string> returnColumns = null)
         {
-            return QueryHelper.CreateQueryFactory(query).Execute(query.AsUpdate(data));
+            return QueryHelper.CreateQueryFactory(query).Execute(query.AsUpdate(data, returnColumns));
         }
 
         public static int Delete(this Query query)

--- a/SqlKata.Execution/Query.Extensions.cs
+++ b/SqlKata.Execution/Query.Extensions.cs
@@ -71,18 +71,19 @@ namespace SqlKata.Execution
             query.Chunk<dynamic>(chunkSize, action);
         }
 
-        public static int Insert(this Query query, IReadOnlyDictionary<string, object> values)
+        public static int Insert(this Query query, IReadOnlyDictionary<string, object> values, IEnumerable<string> returnColumns = null)
         {
-            return QueryHelper.CreateQueryFactory(query).Execute(query.AsInsert(values));
+            return QueryHelper.CreateQueryFactory(query).Execute(query.AsInsert(values, returnColumns));
         }
 
         public static int Insert(
             this Query query,
             IEnumerable<string> columns,
-            IEnumerable<IEnumerable<object>> valuesCollection
+            IEnumerable<IEnumerable<object>> valuesCollection,
+            IEnumerable<string> returnColumns = null
         )
         {
-            return QueryHelper.CreateQueryFactory(query).Execute(query.AsInsert(columns, valuesCollection));
+            return QueryHelper.CreateQueryFactory(query).Execute(query.AsInsert(columns, valuesCollection, returnColumns));
         }
 
         public static int Insert(this Query query, IEnumerable<string> columns, Query fromQuery)
@@ -90,9 +91,9 @@ namespace SqlKata.Execution
             return QueryHelper.CreateQueryFactory(query).Execute(query.AsInsert(columns, fromQuery));
         }
 
-        public static int Insert(this Query query, object data)
+        public static int Insert(this Query query, object data, IEnumerable<string> returnColumns = null)
         {
-            return QueryHelper.CreateQueryFactory(query).Execute(query.AsInsert(data));
+            return QueryHelper.CreateQueryFactory(query).Execute(query.AsInsert(data, returnColumns));
         }
 
         public static T InsertGetId<T>(this Query query, object data)


### PR DESCRIPTION
Implements an argument in Insert/Update-clauses related functions to allow returning columns directly through SQL

**Compatibility:**
- [x] PostgreSQL
- [ ] MSSQL
- [ ] Oracle

I'm still looking on how to implement for MSSQL and Oracle, but comments on PostgreSQL implementation are welcome.

Fixes #8 