### PR TITLE
Feature/custom named parameters

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "dotnet-test-explorer.testProjectPath": "QueryBuilder.Tests/QueryBuilder.Tests.csproj"
+}

--- a/Program/Program.cs
+++ b/Program/Program.cs
@@ -55,7 +55,7 @@ namespace Program
 
         private static QueryFactory SqlLiteQueryFactory()
         {
-            var compiler = new SqliteCompiler();
+            var compiler = new SqliteCompiler() { UseCustomNamedParameters = true };
 
             var connection = new SQLiteConnection("Data Source=Demo.db");
 

--- a/QueryBuilder.Tests/Infrastructure/TestCompilersContainer.cs
+++ b/QueryBuilder.Tests/Infrastructure/TestCompilersContainer.cs
@@ -20,7 +20,7 @@ namespace SqlKata.Tests.Infrastructure
             [EngineCodes.Oracle] = new OracleCompiler(),
             [EngineCodes.PostgreSql] = new PostgresCompiler(),
             [EngineCodes.Sqlite] = new SqliteCompiler(),
-            [EngineCodes.SqlServer] = new SqlServerCompiler()
+            [EngineCodes.SqlServer] = new SqlServerCompiler() { UseCustomNamedParameters = true },
         };
 
         public IEnumerable<string> KnownEngineCodes
@@ -52,7 +52,7 @@ namespace SqlKata.Tests.Infrastructure
         /// <returns></returns>
         public TCompiler Get<TCompiler>(string engineCode) where TCompiler : Compiler
         {
-            return (TCompiler) Get(engineCode);
+            return (TCompiler)Get(engineCode);
         }
 
         /// <summary>

--- a/QueryBuilder/Base.Where.cs
+++ b/QueryBuilder/Base.Where.cs
@@ -7,6 +7,8 @@ namespace SqlKata
 {
     public abstract partial class BaseQuery<Q>
     {
+        public Dictionary<string, object> Variables = new Dictionary<string, object>();
+
         public Q Where(string column, string op, object value)
         {
 

--- a/QueryBuilder/BaseQuery.cs
+++ b/QueryBuilder/BaseQuery.cs
@@ -79,6 +79,15 @@ namespace SqlKata
             clause.Component = component;
             Clauses.Add(clause);
 
+            if (clause is IWithQuery<Q> withQuery)
+            {
+                // Pass Variables up, so they can be found later
+                foreach (var variable in withQuery.Query.Variables)
+                {
+                    Variables[variable.Key] = variable.Value;
+                }
+            }
+
             return (Q)this;
         }
 

--- a/QueryBuilder/Clauses/ColumnClause.cs
+++ b/QueryBuilder/Clauses/ColumnClause.cs
@@ -34,7 +34,7 @@ namespace SqlKata
     /// Represents column clause calculated using query.
     /// </summary>
     /// <seealso cref="AbstractColumn" />
-    public class QueryColumn : AbstractColumn
+    public class QueryColumn : AbstractColumn, IWithQuery<Query>
     {
         /// <summary>
         /// Gets or sets the query that will be used for column value calculation.

--- a/QueryBuilder/Clauses/Combine.cs
+++ b/QueryBuilder/Clauses/Combine.cs
@@ -7,7 +7,7 @@ namespace SqlKata
 
     }
 
-    public class Combine : AbstractCombine
+    public class Combine : AbstractCombine, IWithQuery<Query>
     {
         /// <summary>
         /// Gets or sets the query to be combined with.

--- a/QueryBuilder/Clauses/ConditionClause.cs
+++ b/QueryBuilder/Clauses/ConditionClause.cs
@@ -119,7 +119,7 @@ namespace SqlKata
     /// <summary>
     /// Represents a comparison between a column and a full "subquery".
     /// </summary>
-    public class QueryCondition<T> : AbstractCondition where T : BaseQuery<T>
+    public class QueryCondition<T> : AbstractCondition, IWithQuery<Query> where T : BaseQuery<T>
     {
         public string Column { get; set; }
         public string Operator { get; set; }
@@ -144,7 +144,7 @@ namespace SqlKata
     /// <summary>
     /// Represents a comparison between a full "subquery" and a value.
     /// </summary>
-    public class SubQueryCondition<T> : AbstractCondition where T : BaseQuery<T>
+    public class SubQueryCondition<T> : AbstractCondition, IWithQuery<Query> where T : BaseQuery<T>
     {
         public object Value { get; set; }
         public string Operator { get; set; }
@@ -191,7 +191,7 @@ namespace SqlKata
     /// <summary>
     /// Represents a "is in subquery" condition.
     /// </summary>
-    public class InQueryCondition : AbstractCondition
+    public class InQueryCondition : AbstractCondition, IWithQuery<Query>
     {
         public Query Query { get; set; }
         public string Column { get; set; }
@@ -280,7 +280,7 @@ namespace SqlKata
     /// Represents a "nested" clause condition.
     /// i.e OR (myColumn = "A")
     /// </summary>
-    public class NestedCondition<T> : AbstractCondition where T : BaseQuery<T>
+    public class NestedCondition<T> : AbstractCondition, IWithQuery<T> where T : BaseQuery<T>
     {
         public T Query { get; set; }
         public override AbstractClause Clone()
@@ -299,7 +299,7 @@ namespace SqlKata
     /// <summary>
     /// Represents an "exists sub query" clause condition.
     /// </summary>
-    public class ExistsCondition : AbstractCondition
+    public class ExistsCondition : AbstractCondition, IWithQuery<Query>
     {
         public Query Query { get; set; }
 

--- a/QueryBuilder/Clauses/FromClause.cs
+++ b/QueryBuilder/Clauses/FromClause.cs
@@ -51,7 +51,7 @@ namespace SqlKata
     /// <summary>
     /// Represents a "from subquery" clause.
     /// </summary>
-    public class QueryFromClause : AbstractFrom
+    public class QueryFromClause : AbstractFrom, IWithQuery<Query>
     {
         public Query Query { get; set; }
 

--- a/QueryBuilder/Clauses/IWithQuery.cs
+++ b/QueryBuilder/Clauses/IWithQuery.cs
@@ -1,0 +1,8 @@
+
+namespace SqlKata
+{
+    public interface IWithQuery<Q> where Q : BaseQuery<Q>
+    {
+        Q Query { get; set; }
+    }
+}

--- a/QueryBuilder/Clauses/InsertClause.cs
+++ b/QueryBuilder/Clauses/InsertClause.cs
@@ -26,7 +26,7 @@ namespace SqlKata
         }
     }
 
-    public class InsertQueryClause : AbstractInsertClause
+    public class InsertQueryClause : AbstractInsertClause, IWithQuery<Query>
     {
         public List<string> Columns { get; set; }
         public Query Query { get; set; }

--- a/QueryBuilder/Query.cs
+++ b/QueryBuilder/Query.cs
@@ -12,7 +12,6 @@ namespace SqlKata
         public string Method { get; set; } = "select";
         public string QueryComment { get; set; }
         public List<Include> Includes = new List<Include>();
-        public Dictionary<string, object> Variables = new Dictionary<string, object>();
 
         public Query() : base()
         {


### PR DESCRIPTION
Enabled custom parameter names to be used instead of positional names.

These changes are useful when the user wants to do their own parameter binding/execution.