### PR TITLE
Added support for any IEnumerable<KeyValuePair<string, object>> as values parameter

### DIFF
--- a/QueryBuilder.Tests/GeneralTests.cs
+++ b/QueryBuilder.Tests/GeneralTests.cs
@@ -291,7 +291,7 @@ namespace SqlKata.Tests
             var engines = new[] { EngineCodes.SqlServer, EngineCodes.MySql, EngineCodes.PostgreSql };
             var c = Compilers.Compile(engines, query);
 
-            Assert.Equal(2, query.GetComponents("limit").Count());
+            Assert.Equal(2, query.GetComponents("limit").Count);
             Assert.Equal("SELECT TOP (5) * FROM [mytable]", c[EngineCodes.SqlServer].ToString());
             Assert.Equal("SELECT * FROM \"mytable\" LIMIT 10", c[EngineCodes.PostgreSql].ToString());
             Assert.Equal("SELECT * FROM `mytable`", c[EngineCodes.MySql].ToString());
@@ -319,7 +319,7 @@ namespace SqlKata.Tests
             var engines = new[] { EngineCodes.SqlServer, EngineCodes.MySql, EngineCodes.PostgreSql };
             var c = Compilers.Compile(engines, query);
 
-            Assert.Equal(2, query.GetComponents("offset").Count());
+            Assert.Equal(2, query.GetComponents("offset").Count);
             Assert.Equal("SELECT * FROM `mytable` LIMIT 18446744073709551615 OFFSET 5", c[EngineCodes.MySql].ToString());
             Assert.Equal("SELECT * FROM \"mytable\" OFFSET 10", c[EngineCodes.PostgreSql].ToString());
             Assert.Equal("SELECT * FROM [mytable]", c[EngineCodes.SqlServer].ToString());

--- a/QueryBuilder.Tests/InfrastructureTests.cs
+++ b/QueryBuilder.Tests/InfrastructureTests.cs
@@ -47,7 +47,7 @@ namespace SqlKata.Tests
         [Fact]
         public void ShouldThrowIfAnyEngineCodesAreInvalid()
         {
-            var codes = new[] {EngineCodes.SqlServer, "123", EngineCodes.MySql, "abc"};
+            var codes = new[] { EngineCodes.SqlServer, "123", EngineCodes.MySql, "abc" };
             Assert.Throws<InvalidOperationException>(() => Compilers.Compile(codes, new Query()));
         }
     }

--- a/QueryBuilder.Tests/InsertTests.cs
+++ b/QueryBuilder.Tests/InsertTests.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Dynamic;
 using System.Linq;
 using SqlKata.Compilers;
 using SqlKata.Tests.Infrastructure;
@@ -8,21 +11,44 @@ namespace SqlKata.Tests
 {
     public class InsertTests : TestSupport
     {
+        private class Account
+        {
+            public Account(string name, string currency = null, string created_at = null, string color = null)
+            {
+                this.name = name ?? throw new ArgumentNullException(nameof(name));
+                this.Currency = currency;
+                this.color = color;
+            }
+
+            public string name { get; set; }
+
+            [Column("currency_id")]
+            public string Currency { get; set; }
+
+            [Ignore]
+            public string color { get; set; }
+        }
+
         [Fact]
         public void InsertObject()
         {
-            var query = new Query("Table").AsInsert(new
-            {
-                Name = "The User",
-                Age = new DateTime(2018, 1, 1),
-            });
+            var query = new Query("Table")
+                .AsInsert(
+                    new
+                    {
+                        Name = "The User",
+                        Age = new DateTime(2018, 1, 1),
+                    });
 
             var c = Compile(query);
 
-            Assert.Equal("INSERT INTO [Table] ([Name], [Age]) VALUES ('The User', '2018-01-01')", c[EngineCodes.SqlServer]);
+            Assert.Equal(
+                "INSERT INTO [Table] ([Name], [Age]) VALUES ('The User', '2018-01-01')",
+                c[EngineCodes.SqlServer]);
 
-
-            Assert.Equal("INSERT INTO \"TABLE\" (\"NAME\", \"AGE\") VALUES ('The User', '2018-01-01')", c[EngineCodes.Firebird]);
+            Assert.Equal(
+                "INSERT INTO \"TABLE\" (\"NAME\", \"AGE\") VALUES ('The User', '2018-01-01')",
+                c[EngineCodes.Firebird]);
         }
 
         [Fact]
@@ -32,8 +58,7 @@ namespace SqlKata.Tests
                 .With("old_cards", new Query("all_cars").Where("year", "<", 2000))
                 .AsInsert(
                     new[] { "name", "model", "year" },
-                    new Query("old_cars").Where("price", ">", 100).ForPage(2, 10)
-                );
+                    new Query("old_cars").Where("price", ">", 100).ForPage(2, 10));
 
             var c = Compile(query);
 
@@ -58,18 +83,16 @@ namespace SqlKata.Tests
                     new[] { "name", "brand", "year" },
                     new[]
                     {
-                        new object[] {"Chiron", "Bugatti", null},
-                        new object[] {"Huayra", "Pagani", 2012},
-                        new object[] {"Reventon roadster", "Lamborghini", 2009}
-                    }
-                );
+                        new object[] { "Chiron", "Bugatti", null },
+                        new object[] { "Huayra", "Pagani", 2012 },
+                        new object[] { "Reventon roadster", "Lamborghini", 2009 }
+                    });
 
             var c = Compile(query);
 
             Assert.Equal(
                 "INSERT INTO [expensive_cars] ([name], [brand], [year]) VALUES ('Chiron', 'Bugatti', NULL), ('Huayra', 'Pagani', 2012), ('Reventon roadster', 'Lamborghini', 2009)",
                 c[EngineCodes.SqlServer]);
-
 
             Assert.Equal(
                 "INSERT INTO \"EXPENSIVE_CARS\" (\"NAME\", \"BRAND\", \"YEAR\") SELECT 'Chiron', 'Bugatti', NULL FROM RDB$DATABASE UNION ALL SELECT 'Huayra', 'Pagani', 2012 FROM RDB$DATABASE UNION ALL SELECT 'Reventon roadster', 'Lamborghini', 2009 FROM RDB$DATABASE",
@@ -79,10 +102,10 @@ namespace SqlKata.Tests
         [Fact]
         public void InsertWithNullValues()
         {
-            var query = new Query("Books").AsInsert(
-                new[] { "Id", "Author", "ISBN", "Date" },
-                new object[] { 1, "Author 1", "123456", null }
-            );
+            var query = new Query("Books")
+                .AsInsert(
+                    new[] { "Id", "Author", "ISBN", "Date" },
+                    new object[] { 1, "Author 1", "123456", null });
 
             var c = Compile(query);
 
@@ -98,10 +121,10 @@ namespace SqlKata.Tests
         [Fact]
         public void InsertWithEmptyString()
         {
-            var query = new Query("Books").AsInsert(
-                new[] { "Id", "Author", "ISBN", "Description" },
-                new object[] { 1, "Author 1", "123456", "" }
-            );
+            var query = new Query("Books")
+                .AsInsert(
+                    new[] { "Id", "Author", "ISBN", "Description" },
+                    new object[] { 1, "Author 1", "123456", "" });
 
             var c = Compile(query);
 
@@ -120,7 +143,8 @@ namespace SqlKata.Tests
         {
             var fauxImagebytes = new byte[] { 0x1, 0x3, 0x3, 0x7 };
             var query = new Query("Books")
-                .AsInsert(new[] { "Id", "CoverImageBytes" },
+                .AsInsert(
+                    new[] { "Id", "CoverImageBytes" },
                     new object[]
                     {
                         1,
@@ -131,25 +155,9 @@ namespace SqlKata.Tests
             Assert.All(c.Values, a => Assert.Equal(2, a.NamedBindings.Count));
 
             var exemplar = c[EngineCodes.SqlServer];
+
             Assert.Equal("INSERT INTO [Books] ([Id], [CoverImageBytes]) VALUES (?, ?)", exemplar.RawSql);
             Assert.Equal("INSERT INTO [Books] ([Id], [CoverImageBytes]) VALUES (@p0, @p1)", exemplar.Sql);
-        }
-
-
-        private class Account
-        {
-            public Account(string name, string currency = null, string created_at = null, string color = null)
-            {
-                this.name = name ?? throw new ArgumentNullException("name must be provided");
-                this.Currency = currency;
-                this.color = color;
-            }
-
-            public string name { get; set; }
-            [Column("currency_id")]
-            public string Currency { get; set; }
-            [Ignore]
-            public string color { get; set; }
         }
 
         [Fact]
@@ -172,37 +180,129 @@ namespace SqlKata.Tests
         [Fact]
         public void InsertFromRaw()
         {
-            var query = new Query().FromRaw("Table.With.Dots").AsInsert(new
-            {
-                Name = "The User",
-                Age = new DateTime(2018, 1, 1),
-            });
+            var query = new Query()
+                .FromRaw("Table.With.Dots")
+                .AsInsert(
+                    new
+                    {
+                        Name = "The User",
+                        Age = new DateTime(2018, 1, 1),
+                    });
 
             var c = Compile(query);
 
             Assert.Equal(
                 "INSERT INTO Table.With.Dots ([Name], [Age]) VALUES ('The User', '2018-01-01')",
-                c[EngineCodes.SqlServer]
-            );
-
+                c[EngineCodes.SqlServer]);
         }
-
 
         [Fact]
         public void InsertFromQueryShouldFail()
         {
-            var query = new Query().From(new Query("InnerTable")).AsInsert(new
-            {
-                Name = "The User",
-                Age = new DateTime(2018, 1, 1),
-            });
+            var query = new Query()
+                .From(new Query("InnerTable"))
+                .AsInsert(
+                    new
+                    {
+                        Name = "The User",
+                        Age = new DateTime(2018, 1, 1),
+                    });
 
             Assert.Throws<InvalidOperationException>(() =>
             {
                 Compile(query);
             });
-
         }
 
+        [Fact]
+        public void InsertKeyValuePairs()
+        {
+            var dictionaryUser = new Dictionary<string, object>
+                {
+                    { "Name", "The User" },
+                    { "Age",  new DateTime(2018, 1, 1) },
+                }
+                .ToArray();
+
+            var query = new Query("Table")
+                .AsInsert(dictionaryUser);
+
+            var c = Compile(query);
+
+            Assert.Equal(
+                "INSERT INTO [Table] ([Name], [Age]) VALUES ('The User', '2018-01-01')",
+                c[EngineCodes.SqlServer]);
+
+            Assert.Equal(
+                "INSERT INTO \"TABLE\" (\"NAME\", \"AGE\") VALUES ('The User', '2018-01-01')",
+                c[EngineCodes.Firebird]);
+        }
+
+        [Fact]
+        public void InsertDictionary()
+        {
+            var dictionaryUser = new Dictionary<string, object> {
+                { "Name", "The User" },
+                { "Age",  new DateTime(2018, 1, 1) },
+            };
+
+            var query = new Query("Table")
+                .AsInsert(dictionaryUser);
+
+            var c = Compile(query);
+
+            Assert.Equal(
+                "INSERT INTO [Table] ([Name], [Age]) VALUES ('The User', '2018-01-01')",
+                c[EngineCodes.SqlServer]);
+
+            Assert.Equal(
+                "INSERT INTO \"TABLE\" (\"NAME\", \"AGE\") VALUES ('The User', '2018-01-01')",
+                c[EngineCodes.Firebird]);
+        }
+
+        [Fact]
+        public void InsertReadOnlyDictionary()
+        {
+            var dictionaryUser = new ReadOnlyDictionary<string, object>(
+                new Dictionary<string, object>
+                {
+                    { "Name", "The User" },
+                    { "Age",  new DateTime(2018, 1, 1) },
+                });
+
+            var query = new Query("Table")
+                .AsInsert(dictionaryUser);
+
+            var c = Compile(query);
+
+            Assert.Equal(
+                "INSERT INTO [Table] ([Name], [Age]) VALUES ('The User', '2018-01-01')",
+                c[EngineCodes.SqlServer]);
+
+            Assert.Equal(
+                "INSERT INTO \"TABLE\" (\"NAME\", \"AGE\") VALUES ('The User', '2018-01-01')",
+                c[EngineCodes.Firebird]);
+        }
+
+        [Fact]
+        public void InsertExpandoObject()
+        {
+            dynamic expandoUser = new ExpandoObject();
+            expandoUser.Name = "The User";
+            expandoUser.Age = new DateTime(2018, 1, 1);
+
+            var query = new Query("Table")
+                .AsInsert(expandoUser);
+
+            var c = Compile(query);
+
+            Assert.Equal(
+                "INSERT INTO [Table] ([Name], [Age]) VALUES ('The User', '2018-01-01')",
+                c[EngineCodes.SqlServer]);
+
+            Assert.Equal(
+                "INSERT INTO \"TABLE\" (\"NAME\", \"AGE\") VALUES ('The User', '2018-01-01')",
+                c[EngineCodes.Firebird]);
+        }
     }
 }

--- a/QueryBuilder.Tests/UpdateTests.cs
+++ b/QueryBuilder.Tests/UpdateTests.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Dynamic;
+using System.Linq;
 using SqlKata.Compilers;
 using SqlKata.Tests.Infrastructure;
 using Xunit;
@@ -8,117 +11,27 @@ namespace SqlKata.Tests
 {
     public class UpdateTests : TestSupport
     {
-        [Fact]
-        public void UpdateObject()
-        {
-            var query = new Query("Table").AsUpdate(new
-            {
-                Name = "The User",
-                Age = new DateTime(2018, 1, 1),
-            });
-
-            var c = Compile(query);
-
-            Assert.Equal("UPDATE [Table] SET [Name] = 'The User', [Age] = '2018-01-01'", c[EngineCodes.SqlServer]);
-
-
-            Assert.Equal("UPDATE \"TABLE\" SET \"NAME\" = 'The User', \"AGE\" = '2018-01-01'", c[EngineCodes.Firebird]);
-        }
-
-        [Fact]
-        public void UpdateWithNullValues()
-        {
-            var query = new Query("Books").Where("Id", 1).AsUpdate(
-                new[] { "Author", "Date", "Version" },
-                new object[] { "Author 1", null, null }
-            );
-
-            var c = Compile(query);
-
-            Assert.Equal("UPDATE [Books] SET [Author] = 'Author 1', [Date] = NULL, [Version] = NULL WHERE [Id] = 1",
-                c[EngineCodes.SqlServer]);
-
-
-            Assert.Equal(
-                "UPDATE \"BOOKS\" SET \"AUTHOR\" = 'Author 1', \"DATE\" = NULL, \"VERSION\" = NULL WHERE \"ID\" = 1",
-                c[EngineCodes.Firebird]);
-        }
-
-        [Fact]
-        public void UpdateWithEmptyString()
-        {
-            var query = new Query("Books").Where("Id", 1).AsUpdate(
-                new[] { "Author", "Description" },
-                new object[] { "Author 1", "" }
-            );
-
-            var c = Compile(query);
-
-            Assert.Equal("UPDATE [Books] SET [Author] = 'Author 1', [Description] = '' WHERE [Id] = 1", c[EngineCodes.SqlServer]);
-
-
-            Assert.Equal("UPDATE \"BOOKS\" SET \"AUTHOR\" = 'Author 1', \"DESCRIPTION\" = '' WHERE \"ID\" = 1", c[EngineCodes.Firebird]);
-        }
-
-        [Fact]
-        public void UpdateWithCte()
-        {
-            var now = DateTime.UtcNow.ToString("yyyy-MM-dd");
-
-            var query = new Query("Books")
-                .With("OldBooks", q => q.From("Books").Where("Date", "<", now))
-                .Where("Price", ">", 100)
-                .AsUpdate(new Dictionary<string, object>
-                {
-                    {"Price", "150"}
-                });
-
-            var c = Compile(query);
-
-            Assert.Equal(
-                $"WITH [OldBooks] AS (SELECT * FROM [Books] WHERE [Date] < '{now}')\nUPDATE [Books] SET [Price] = '150' WHERE [Price] > 100",
-                c[EngineCodes.SqlServer]);
-        }
-
-
         private class Book
         {
             public Book(string name, string author, decimal price = 1.0m, string color = null)
             {
-                this.Name = name ?? throw new ArgumentNullException("name must be provided");
+                this.Name = name ?? throw new ArgumentNullException(nameof(name));
                 this.BookPrice = price;
                 this.color = color;
                 this.BookAuthor = author;
             }
 
             public string Name { get; set; }
+
             [Column("Author")]
             public string BookAuthor { get; set; }
+
             [Column("Price")]
             public decimal BookPrice { get; set; }
+
             [Ignore]
             public string color { get; set; }
         }
-
-        [Fact]
-        public void UpdateWithIgnoreAndColumnProperties()
-        {
-            var book = new Book(name: $"SqlKataBook", author: "Kata", color: $"red", price: 100m);
-            var query = new Query("Book").AsUpdate(book);
-
-            var c = Compile(query);
-
-            Assert.Equal(
-                "UPDATE [Book] SET [Name] = 'SqlKataBook', [Author] = 'Kata', [Price] = 100",
-                c[EngineCodes.SqlServer]);
-
-
-            Assert.Equal(
-                "UPDATE \"BOOK\" SET \"NAME\" = 'SqlKataBook', \"AUTHOR\" = 'Kata', \"PRICE\" = 100",
-                c[EngineCodes.Firebird]);
-        }
-
-
 
         private class OrderProductComposite
         {
@@ -143,24 +56,112 @@ namespace SqlKata.Tests
         }
 
         [Fact]
-        public void UpdateWithKeyAttribute()
+        public void UpdateObject()
         {
-            var order = new OrderProductComposite("ORD01", "PROD02", 20);
-
-            var query = new Query("OrderProductComposite").AsUpdate(order);
+            var query = new Query("Table").AsUpdate(new
+            {
+                Name = "The User",
+                Age = new DateTime(2018, 1, 1),
+            });
 
             var c = Compile(query);
 
+            Assert.Equal(
+                "UPDATE [Table] SET [Name] = 'The User', [Age] = '2018-01-01'",
+                c[EngineCodes.SqlServer]);
+
+            Assert.Equal(
+                "UPDATE \"TABLE\" SET \"NAME\" = 'The User', \"AGE\" = '2018-01-01'",
+                c[EngineCodes.Firebird]);
+        }
+
+        [Fact]
+        public void UpdateWithNullValues()
+        {
+            var query = new Query("Books").Where("Id", 1).AsUpdate(
+                new[] { "Author", "Date", "Version" },
+                new object[] { "Author 1", null, null }
+            );
+
+            var c = Compile(query);
+
+            Assert.Equal(
+                "UPDATE [Books] SET [Author] = 'Author 1', [Date] = NULL, [Version] = NULL WHERE [Id] = 1",
+                c[EngineCodes.SqlServer]);
+
+            Assert.Equal(
+                "UPDATE \"BOOKS\" SET \"AUTHOR\" = 'Author 1', \"DATE\" = NULL, \"VERSION\" = NULL WHERE \"ID\" = 1",
+                c[EngineCodes.Firebird]);
+        }
+
+        [Fact]
+        public void UpdateWithEmptyString()
+        {
+            var query = new Query("Books").Where("Id", 1).AsUpdate(
+                new[] { "Author", "Description" },
+                new object[] { "Author 1", "" }
+            );
+
+            var c = Compile(query);
+
+            Assert.Equal("UPDATE [Books] SET [Author] = 'Author 1', [Description] = '' WHERE [Id] = 1", c[EngineCodes.SqlServer]);
+
+            Assert.Equal("UPDATE \"BOOKS\" SET \"AUTHOR\" = 'Author 1', \"DESCRIPTION\" = '' WHERE \"ID\" = 1", c[EngineCodes.Firebird]);
+        }
+
+        [Fact]
+        public void UpdateWithCte()
+        {
+            var now = DateTime.UtcNow.ToString("yyyy-MM-dd");
+
+            var query = new Query("Books")
+                .With("OldBooks", q => q.From("Books").Where("Date", "<", now))
+                .Where("Price", ">", 100)
+                .AsUpdate(new Dictionary<string, object>
+                {
+                    {"Price", "150"}
+                });
+
+            var c = Compile(query);
+
+            Assert.Equal(
+                $"WITH [OldBooks] AS (SELECT * FROM [Books] WHERE [Date] < '{now}')\nUPDATE [Books] SET [Price] = '150' WHERE [Price] > 100",
+                c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
+        public void UpdateWithIgnoreAndColumnProperties()
+        {
+            var book = new Book(name: $"SqlKataBook", author: "Kata", color: $"red", price: 100m);
+            var query = new Query("Book").AsUpdate(book);
+
+            var c = Compile(query);
+
+            Assert.Equal(
+                "UPDATE [Book] SET [Name] = 'SqlKataBook', [Author] = 'Kata', [Price] = 100",
+                c[EngineCodes.SqlServer]);
+
+            Assert.Equal(
+                "UPDATE \"BOOK\" SET \"NAME\" = 'SqlKataBook', \"AUTHOR\" = 'Kata', \"PRICE\" = 100",
+                c[EngineCodes.Firebird]);
+        }
+
+        [Fact]
+        public void UpdateWithKeyAttribute()
+        {
+            var order = new OrderProductComposite("ORD01", "PROD02", 20);
+            var query = new Query("OrderProductComposite").AsUpdate(order);
+
+            var c = Compile(query);
 
             Assert.Equal(
                 "UPDATE [OrderProductComposite] SET [OrdId] = 'ORD01', [ProductId] = 'PROD02', [Quantity] = 20, [Faa] = 'baz' WHERE [OrdId] = 'ORD01' AND [ProductId] = 'PROD02'",
                 c[EngineCodes.SqlServer]);
 
             Assert.Equal(
-              "UPDATE \"ORDERPRODUCTCOMPOSITE\" SET \"ORDID\" = 'ORD01', \"PRODUCTID\" = 'PROD02', \"QUANTITY\" = 20, \"FAA\" = 'baz' WHERE \"ORDID\" = 'ORD01' AND \"PRODUCTID\" = 'PROD02'",
-              c[EngineCodes.Firebird]);
+                "UPDATE \"ORDERPRODUCTCOMPOSITE\" SET \"ORDID\" = 'ORD01', \"PRODUCTID\" = 'PROD02', \"QUANTITY\" = 20, \"FAA\" = 'baz' WHERE \"ORDID\" = 'ORD01' AND \"PRODUCTID\" = 'PROD02'",
+                c[EngineCodes.Firebird]);
         }
-
 
         [Fact]
         public void UpdateFromRaw()
@@ -174,10 +175,8 @@ namespace SqlKata.Tests
 
             Assert.Equal(
                 "UPDATE Table.With.Dots SET [Name] = 'The User'",
-                c[EngineCodes.SqlServer]
-            );
+                c[EngineCodes.SqlServer]);
         }
-
 
         [Fact]
         public void UpdateFromQueryShouldFail()
@@ -191,13 +190,11 @@ namespace SqlKata.Tests
             {
                 Compile(query);
             });
-
         }
 
         [Fact]
         public void update_should_compile_literal_without_parameters_holders()
         {
-
             var query = new Query("MyTable").AsUpdate(new
             {
                 Name = "The User",
@@ -205,13 +202,86 @@ namespace SqlKata.Tests
             });
 
             var compiler = new SqlServerCompiler();
-            var result =  compiler.Compile(query);
+            var result = compiler.Compile(query);
 
             Assert.Equal(
                 "UPDATE [MyTable] SET [Name] = ?, [Address] = @address",
-                result.RawSql
-            );
+                result.RawSql);
         }
 
+        [Fact]
+        public void UpdateUsingKeyValuePairs()
+        {
+            var dictionaryUser = new Dictionary<string, object>
+                {
+                    { "Name", "The User" },
+                    { "Age",  new DateTime(2018, 1, 1) },
+                }
+                .ToArray();
+
+            var query = new Query("Table")
+                .AsUpdate(dictionaryUser);
+
+            var c = Compile(query);
+
+            Assert.Equal(
+                "UPDATE [Table] SET [Name] = 'The User', [Age] = '2018-01-01'",
+                c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
+        public void UpdateUsingDictionary()
+        {
+            var dictionaryUser = new Dictionary<string, object> {
+                { "Name", "The User" },
+                { "Age",  new DateTime(2018, 1, 1) },
+            };
+
+            var query = new Query("Table")
+                .AsUpdate(dictionaryUser);
+
+            var c = Compile(query);
+
+            Assert.Equal(
+                "UPDATE [Table] SET [Name] = 'The User', [Age] = '2018-01-01'",
+                c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
+        public void UpdateUsingReadOnlyDictionary()
+        {
+            var dictionaryUser = new ReadOnlyDictionary<string, object>(
+                new Dictionary<string, object>
+                {
+                    { "Name", "The User" },
+                    { "Age",  new DateTime(2018, 1, 1) },
+                });
+
+            var query = new Query("Table")
+                .AsUpdate(dictionaryUser);
+
+            var c = Compile(query);
+
+            Assert.Equal(
+                "UPDATE [Table] SET [Name] = 'The User', [Age] = '2018-01-01'",
+                c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
+        public void UpdateUsingExpandoObject()
+        {
+            dynamic expandoUser = new ExpandoObject();
+            expandoUser.Name = "The User";
+            expandoUser.Age = new DateTime(2018, 1, 1);
+
+            var query = new Query("Table")
+                .AsUpdate(expandoUser);
+
+            var c = Compile(query);
+
+            Assert.Equal(
+                "UPDATE [Table] SET [Name] = 'The User', [Age] = '2018-01-01'",
+                c[EngineCodes.SqlServer]);
+        }
     }
 }

--- a/QueryBuilder/Base.Where.cs
+++ b/QueryBuilder/Base.Where.cs
@@ -77,7 +77,7 @@ namespace SqlKata
             return Where(dictionary);
         }
 
-        public Q Where(IReadOnlyDictionary<string, object> values)
+        public Q Where(IEnumerable<KeyValuePair<string, object>> values)
         {
             var query = (Q)this;
             var orFlag = GetOr();

--- a/QueryBuilder/Base.Where.cs
+++ b/QueryBuilder/Base.Where.cs
@@ -526,7 +526,7 @@ namespace SqlKata
         {
             if (!query.HasComponent("from"))
             {
-                throw new ArgumentException("'FromClause' cannot be empty if used inside a 'WhereExists' condition");
+                throw new ArgumentException($"'{nameof(FromClause)}' cannot be empty if used inside a '{nameof(WhereExists)}' condition");
             }
 
             // remove unneeded components
@@ -572,8 +572,6 @@ namespace SqlKata
         {
             return Or().Not().WhereExists(callback);
         }
-
-
 
         #region date
         public Q WhereDatePart(string part, string column, string op, object value)
@@ -691,6 +689,5 @@ namespace SqlKata
         }
 
         #endregion
-
     }
 }

--- a/QueryBuilder/BaseQuery.cs
+++ b/QueryBuilder/BaseQuery.cs
@@ -45,7 +45,7 @@ namespace SqlKata
         {
             if (this == parent)
             {
-                throw new ArgumentException("Cannot set the same query as a parent of itself");
+                throw new ArgumentException($"Cannot set the same {nameof(AbstractQuery)} as a parent of itself");
             }
 
             this.Parent = parent;

--- a/QueryBuilder/Clauses/ConditionClause.cs
+++ b/QueryBuilder/Clauses/ConditionClause.cs
@@ -48,7 +48,7 @@ namespace SqlKata
                 if (string.IsNullOrWhiteSpace(value))
                     value = null;
                 else if (value.Length > 1)
-                    throw new ArgumentOutOfRangeException("The EscapeCharacter can only contain a single character!");
+                    throw new ArgumentOutOfRangeException($"The {nameof(EscapeCharacter)} can only contain a single character!");
                 escapeCharacter = value;
             }
         }

--- a/QueryBuilder/ColumnAttribute.cs
+++ b/QueryBuilder/ColumnAttribute.cs
@@ -12,14 +12,12 @@ namespace SqlKata
         {
             if (string.IsNullOrEmpty(name))
             {
-                throw new ArgumentNullException("Name parameter is required");
+                throw new ArgumentNullException(nameof(name));
             }
 
             Name = name;
         }
-
     }
-
 
     /// <summary>
     /// This class is used as metadata on a property to determine if it is a primary key

--- a/QueryBuilder/Compilers/ConditionsCompilerProvider.cs
+++ b/QueryBuilder/Compilers/ConditionsCompilerProvider.cs
@@ -40,7 +40,7 @@ namespace SqlKata.Compilers
 
             if (methodInfo == null)
             {
-                throw new Exception($"Failed to locate a compiler for {methodName}.");
+                throw new Exception($"Failed to locate a compiler for '{methodName}'.");
             }
 
             if (clauseType.IsConstructedGenericType && methodInfo.GetGenericArguments().Any())

--- a/QueryBuilder/Compilers/SqliteCompiler.cs
+++ b/QueryBuilder/Compilers/SqliteCompiler.cs
@@ -43,13 +43,13 @@ namespace SqlKata.Compilers
             var value = Parameter(ctx, condition.Value);
 
             var formatMap = new Dictionary<string, string> {
-                {"date", "%Y-%m-%d"},
-                {"time", "%H:%M:%S"},
-                {"year", "%Y"},
-                {"month", "%m"},
-                {"day", "%d"},
-                {"hour", "%H"},
-                {"minute", "%M"},
+                { "date", "%Y-%m-%d" },
+                { "time", "%H:%M:%S" },
+                { "year", "%Y" },
+                { "month", "%m" },
+                { "day", "%d" },
+                { "hour", "%H" },
+                { "minute", "%M" },
             };
 
             if (!formatMap.ContainsKey(condition.Part))
@@ -66,6 +66,5 @@ namespace SqlKata.Compilers
 
             return sql;
         }
-
     }
 }

--- a/QueryBuilder/Query.Having.cs
+++ b/QueryBuilder/Query.Having.cs
@@ -77,7 +77,7 @@ namespace SqlKata
             return Having(dictionary);
         }
 
-        public Query Having(IReadOnlyDictionary<string, object> values)
+        public Query Having(IEnumerable<KeyValuePair<string, object>> values)
         {
             var query = this;
             var orFlag = GetOr();

--- a/QueryBuilder/Query.Having.cs
+++ b/QueryBuilder/Query.Having.cs
@@ -488,7 +488,7 @@ namespace SqlKata
         {
             if (!query.HasComponent("from"))
             {
-                throw new ArgumentException("'FromClause' cannot be empty if used inside a 'HavingExists' condition");
+                throw new ArgumentException($"{nameof(FromClause)} cannot be empty if used inside a {nameof(HavingExists)} condition");
             }
 
             // simplify the query as much as possible

--- a/QueryBuilder/Query.Insert.cs
+++ b/QueryBuilder/Query.Insert.cs
@@ -9,7 +9,7 @@ namespace SqlKata
     {
         public Query AsInsert(object data, bool returnId = false)
         {
-            var dictionary = BuildDictionaryFromObject(data);
+            var dictionary = BuildKeyValuePairsFromObject(data);
 
             return AsInsert(dictionary, returnId);
         }
@@ -42,7 +42,7 @@ namespace SqlKata
 
         public Query AsInsert(IEnumerable<KeyValuePair<string, object>> data, bool returnId = false)
         {
-            if (data == null || data.Count == 0)
+            if (data == null || data.Any() == false)
             {
                 throw new InvalidOperationException("Values dictionary cannot be null or empty");
             }
@@ -51,8 +51,8 @@ namespace SqlKata
 
             ClearComponent("insert").AddComponent("insert", new InsertClause
             {
-                Columns = data.Keys.ToList(),
-                Values = data.Values.ToList(),
+                Columns = data.Select(x=>x.Key).ToList(),
+                Values = data.Select(x => x.Value).ToList(),
                 ReturnId = returnId,
             });
 

--- a/QueryBuilder/Query.Insert.cs
+++ b/QueryBuilder/Query.Insert.cs
@@ -9,9 +9,9 @@ namespace SqlKata
     {
         public Query AsInsert(object data, bool returnId = false)
         {
-            var dictionary = BuildKeyValuePairsFromObject(data);
+            var propertiesKeyValues = BuildKeyValuePairsFromObject(data);
 
-            return AsInsert(dictionary, returnId);
+            return AsInsert(propertiesKeyValues, returnId);
         }
 
         public Query AsInsert(IEnumerable<string> columns, IEnumerable<object> values)
@@ -21,12 +21,12 @@ namespace SqlKata
 
             if ((columnsList?.Count ?? 0) == 0 || (valuesList?.Count ?? 0) == 0)
             {
-                throw new InvalidOperationException("Columns and Values cannot be null or empty");
+                throw new InvalidOperationException($"{nameof(columns)} and {nameof(values)} cannot be null or empty");
             }
 
             if (columnsList.Count != valuesList.Count)
             {
-                throw new InvalidOperationException("Columns count should be equal to Values count");
+                throw new InvalidOperationException($"{nameof(columns)} and {nameof(values)} cannot be null or empty");
             }
 
             Method = "insert";
@@ -40,19 +40,19 @@ namespace SqlKata
             return this;
         }
 
-        public Query AsInsert(IEnumerable<KeyValuePair<string, object>> data, bool returnId = false)
+        public Query AsInsert(IEnumerable<KeyValuePair<string, object>> values, bool returnId = false)
         {
-            if (data == null || data.Any() == false)
+            if (values == null || values.Any() == false)
             {
-                throw new InvalidOperationException("Values dictionary cannot be null or empty");
+                throw new InvalidOperationException($"{values} argument cannot be null or empty");
             }
 
             Method = "insert";
 
             ClearComponent("insert").AddComponent("insert", new InsertClause
             {
-                Columns = data.Select(x=>x.Key).ToList(),
-                Values = data.Select(x => x.Value).ToList(),
+                Columns = values.Select(x=>x.Key).ToList(),
+                Values = values.Select(x => x.Value).ToList(),
                 ReturnId = returnId,
             });
 
@@ -63,16 +63,16 @@ namespace SqlKata
         /// Produces insert multi records
         /// </summary>
         /// <param name="columns"></param>
-        /// <param name="valuesCollection"></param>
+        /// <param name="rowsValues"></param>
         /// <returns></returns>
-        public Query AsInsert(IEnumerable<string> columns, IEnumerable<IEnumerable<object>> valuesCollection)
+        public Query AsInsert(IEnumerable<string> columns, IEnumerable<IEnumerable<object>> rowsValues)
         {
             var columnsList = columns?.ToList();
-            var valuesCollectionList = valuesCollection?.ToList();
+            var valuesCollectionList = rowsValues?.ToList();
 
             if ((columnsList?.Count ?? 0) == 0 || (valuesCollectionList?.Count ?? 0) == 0)
             {
-                throw new InvalidOperationException("Columns and valuesCollection cannot be null or empty");
+                throw new InvalidOperationException($"{nameof(columns)} and {nameof(rowsValues)} cannot be null or empty");
             }
 
             Method = "insert";
@@ -84,7 +84,7 @@ namespace SqlKata
                 var valuesList = values.ToList();
                 if (columnsList.Count != valuesList.Count)
                 {
-                    throw new InvalidOperationException("Columns count should be equal to each Values count");
+                    throw new InvalidOperationException($"{nameof(columns)} count should be equal to each {nameof(rowsValues)} entry count");
                 }
 
                 AddComponent("insert", new InsertClause
@@ -115,6 +115,5 @@ namespace SqlKata
 
             return this;
         }
-
     }
 }

--- a/QueryBuilder/Query.Insert.cs
+++ b/QueryBuilder/Query.Insert.cs
@@ -40,7 +40,7 @@ namespace SqlKata
             return this;
         }
 
-        public Query AsInsert(IReadOnlyDictionary<string, object> data, bool returnId = false)
+        public Query AsInsert(IEnumerable<KeyValuePair<string, object>> data, bool returnId = false)
         {
             if (data == null || data.Count == 0)
             {

--- a/QueryBuilder/Query.Update.cs
+++ b/QueryBuilder/Query.Update.cs
@@ -11,7 +11,7 @@ namespace SqlKata
 
         public Query AsUpdate(object data)
         {
-            var dictionary = BuildDictionaryFromObject(data, considerKeys: true);
+            var dictionary = BuildKeyValuePairsFromObject(data, considerKeys: true);
 
             return AsUpdate(dictionary);
         }
@@ -40,10 +40,10 @@ namespace SqlKata
             return this;
         }
 
-        public Query AsUpdate(IReadOnlyDictionary<string, object> data)
+        public Query AsUpdate(IEnumerable<KeyValuePair<string, object>> data)
         {
 
-            if (data == null || data.Count == 0)
+            if (data == null || data.Any() == false)
             {
                 throw new InvalidOperationException("Values dictionary cannot be null or empty");
             }
@@ -52,8 +52,8 @@ namespace SqlKata
 
             ClearComponent("update").AddComponent("update", new InsertClause
             {
-                Columns = data.Keys.ToList(),
-                Values = data.Values.ToList(),
+                Columns = data.Select(x => x.Key).ToList(),
+                Values = data.Select(x => x.Value).ToList(),
             });
 
             return this;

--- a/QueryBuilder/Query.Update.cs
+++ b/QueryBuilder/Query.Update.cs
@@ -5,10 +5,8 @@ using System.Reflection;
 
 namespace SqlKata
 {
-
     public partial class Query
     {
-
         public Query AsUpdate(object data)
         {
             var dictionary = BuildKeyValuePairsFromObject(data, considerKeys: true);
@@ -18,15 +16,14 @@ namespace SqlKata
 
         public Query AsUpdate(IEnumerable<string> columns, IEnumerable<object> values)
         {
-
-            if ((columns?.Count() ?? 0) == 0 || (values?.Count() ?? 0) == 0)
+            if ((columns?.Any() ?? false) == false || (values?.Any() ?? false) == false)
             {
-                throw new InvalidOperationException("Columns and Values cannot be null or empty");
+                throw new InvalidOperationException($"{columns} and {values} cannot be null or empty");
             }
 
             if (columns.Count() != values.Count())
             {
-                throw new InvalidOperationException("Columns count should be equal to Values count");
+                throw new InvalidOperationException($"{columns} count should be equal to {values} count");
             }
 
             Method = "update";
@@ -40,24 +37,22 @@ namespace SqlKata
             return this;
         }
 
-        public Query AsUpdate(IEnumerable<KeyValuePair<string, object>> data)
+        public Query AsUpdate(IEnumerable<KeyValuePair<string, object>> values)
         {
-
-            if (data == null || data.Any() == false)
+            if (values == null || values.Any() == false)
             {
-                throw new InvalidOperationException("Values dictionary cannot be null or empty");
+                throw new InvalidOperationException($"{values} cannot be null or empty");
             }
 
             Method = "update";
 
             ClearComponent("update").AddComponent("update", new InsertClause
             {
-                Columns = data.Select(x => x.Key).ToList(),
-                Values = data.Select(x => x.Value).ToList(),
+                Columns = values.Select(x => x.Key).ToList(),
+                Values = values.Select(x => x.Value).ToList(),
             });
 
             return this;
         }
-
     }
 }

--- a/QueryBuilder/Query.cs
+++ b/QueryBuilder/Query.cs
@@ -24,7 +24,6 @@ namespace SqlKata
             Comment(comment);
         }
 
-
         public bool HasOffset(string engineCode = null) => GetOffset(engineCode) > 0;
 
         public bool HasLimit(string engineCode = null) => GetLimit(engineCode) > 0;
@@ -345,17 +344,16 @@ namespace SqlKata
         }
 
         /// <summary>
-        /// Build a dictionary from plain object, intended to be used with Insert and Update queries
+        /// Gather a list of key-values representing the properties of the object and their values.
         /// </summary>
-        /// <param name="data">the plain C# object</param>
+        /// <param name="data">The plain C# object</param>
         /// <param name="considerKeys">
         /// When true it will search for properties with the [Key] attribute
-        /// and add it automatically to the Where clause
+        /// and will add it automatically to the Where clause
         /// </param>
         /// <returns></returns>
         private IEnumerable<KeyValuePair<string, object>> BuildKeyValuePairsFromObject(object data, bool considerKeys = false)
         {
-
             var dictionary = new Dictionary<string, object>();
             var props = data.GetType().GetRuntimeProperties();
 
@@ -381,11 +379,9 @@ namespace SqlKata
                         this.Where(name, value);
                     }
                 }
-
             }
 
             return dictionary;
         }
-
     }
 }

--- a/QueryBuilder/Query.cs
+++ b/QueryBuilder/Query.cs
@@ -353,7 +353,7 @@ namespace SqlKata
         /// and add it automatically to the Where clause
         /// </param>
         /// <returns></returns>
-        private Dictionary<string, object> BuildDictionaryFromObject(object data, bool considerKeys = false)
+        private IEnumerable<KeyValuePair<string, object>> BuildKeyValuePairsFromObject(object data, bool considerKeys = false)
         {
 
             var dictionary = new Dictionary<string, object>();

--- a/QueryBuilder/SqlResult.cs
+++ b/QueryBuilder/SqlResult.cs
@@ -34,7 +34,7 @@ namespace SqlKata
                 if (i >= deepParameters.Count)
                 {
                     throw new Exception(
-                        $"Failed to retrieve a binding at the index {i}, the total bindings count is {Bindings.Count}");
+                        $"Failed to retrieve a binding at index {i}, the total bindings count is {Bindings.Count}");
                 }
 
                 var value = deepParameters[i];
@@ -44,7 +44,6 @@ namespace SqlKata
 
         private string ChangeToSqlValue(object value)
         {
-
             if (value == null)
             {
                 return "NULL";
@@ -83,8 +82,5 @@ namespace SqlKata
             // fallback to string
             return "'" + value.ToString() + "'";
         }
-
-
-
     }
 }

--- a/SqlKata.Execution/Query.Extensions.cs
+++ b/SqlKata.Execution/Query.Extensions.cs
@@ -324,10 +324,15 @@ namespace SqlKata.Execution
             {
                 if (method == null)
                 {
-                    throw new InvalidOperationException($"Execution methods can only be used with `XQuery` instances, consider using the `QueryFactory.Query()` to create executable queries, check https://sqlkata.com/docs/execution/setup#xquery-class for more info");
+                    throw new InvalidOperationException(
+                        $"Execution methods can only be used with `{nameof(XQuery)}` instances, " +
+                        $"consider using the `{nameof(QueryFactory)}.{nameof(QueryFactory.Query)}()` to create executable queries, " +
+                        $"check https://sqlkata.com/docs/execution/setup#xquery-class for more info");
                 }
 
-                throw new InvalidOperationException($"The method ${method} can only be used with `XQuery` instances, consider using the `QueryFactory.Query()` to create executable queries, check https://sqlkata.com/docs/execution/setup#xquery-class for more info");
+                throw new InvalidOperationException($"The method '{method}()' can only be used with `{nameof(XQuery)}` instances, " +
+                    $"consider using the `{nameof(QueryFactory)}.{nameof(QueryFactory.Query)}()` to create executable queries, " +
+                    $"check https://sqlkata.com/docs/execution/setup#xquery-class for more info");
             }
 
             return xQuery;
@@ -346,6 +351,5 @@ namespace SqlKata.Execution
         {
             return CreateQueryFactory(CastToXQuery(query));
         }
-
     }
 }

--- a/SqlKata.Execution/Query.Extensions.cs
+++ b/SqlKata.Execution/Query.Extensions.cs
@@ -153,12 +153,12 @@ namespace SqlKata.Execution
             await ChunkAsync<dynamic>(query, chunkSize, action, transaction, timeout);
         }
 
-        public static int Insert(this Query query, IReadOnlyDictionary<string, object> values, IDbTransaction transaction = null, int? timeout = null)
+        public static int Insert(this Query query, IEnumerable<KeyValuePair<string, object>> values, IDbTransaction transaction = null, int? timeout = null)
         {
             return CreateQueryFactory(query).Execute(query.AsInsert(values), transaction, timeout);
         }
 
-        public static async Task<int> InsertAsync(this Query query, IReadOnlyDictionary<string, object> values, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<int> InsertAsync(this Query query, IEnumerable<KeyValuePair<string, object>> values, IDbTransaction transaction = null, int? timeout = null)
         {
             return await CreateQueryFactory(query).ExecuteAsync(query.AsInsert(values), transaction, timeout);
         }
@@ -205,26 +205,26 @@ namespace SqlKata.Execution
             return row.Id;
         }
 
-        public static T InsertGetId<T>(this Query query, IReadOnlyDictionary<string, object> data, IDbTransaction transaction = null, int? timeout = null)
+        public static T InsertGetId<T>(this Query query, IEnumerable<KeyValuePair<string, object>> data, IDbTransaction transaction = null, int? timeout = null)
         {
             var row = CreateQueryFactory(query).First<InsertGetIdRow<T>>(query.AsInsert(data, true), transaction, timeout);
 
             return row.Id;
         }
 
-        public static async Task<T> InsertGetIdAsync<T>(this Query query, IReadOnlyDictionary<string, object> data, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<T> InsertGetIdAsync<T>(this Query query, IEnumerable<KeyValuePair<string, object>> data, IDbTransaction transaction = null, int? timeout = null)
         {
             var row = await CreateQueryFactory(query).FirstAsync<InsertGetIdRow<T>>(query.AsInsert(data, true), transaction, timeout);
 
             return row.Id;
         }
 
-        public static int Update(this Query query, IReadOnlyDictionary<string, object> values, IDbTransaction transaction = null, int? timeout = null)
+        public static int Update(this Query query, IEnumerable<KeyValuePair<string, object>> values, IDbTransaction transaction = null, int? timeout = null)
         {
             return CreateQueryFactory(query).Execute(query.AsUpdate(values), transaction, timeout);
         }
 
-        public static async Task<int> UpdateAsync(this Query query, IReadOnlyDictionary<string, object> values, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<int> UpdateAsync(this Query query, IEnumerable<KeyValuePair<string, object>> values, IDbTransaction transaction = null, int? timeout = null)
         {
             return await CreateQueryFactory(query).ExecuteAsync(query.AsUpdate(values), transaction, timeout);
         }

--- a/SqlKata.Execution/QueryFactory.cs
+++ b/SqlKata.Execution/QueryFactory.cs
@@ -271,14 +271,12 @@ namespace SqlKata.Execution
                 transaction,
                 timeout ?? this.QueryTimeout
             );
-
         }
 
         public async Task<SqlMapper.GridReader> GetMultipleAsync<T>(
             Query[] queries,
             IDbTransaction transaction = null,
-            int? timeout = null
-        )
+            int? timeout = null)
         {
             var compiled = this.Compiler.Compile(queries);
 
@@ -288,8 +286,6 @@ namespace SqlKata.Execution
                 transaction,
                 timeout ?? this.QueryTimeout
             );
-
-
         }
 
         public IEnumerable<IEnumerable<T>> Get<T>(
@@ -307,12 +303,11 @@ namespace SqlKata.Execution
 
             using (multi)
             {
-                for (var i = 0; i < queries.Count(); i++)
+                for (var i = 0; i < queries.Length; i++)
                 {
                     yield return multi.Read<T>();
                 }
             }
-
         }
 
         public async Task<IEnumerable<IEnumerable<T>>> GetAsync<T>(
@@ -321,7 +316,6 @@ namespace SqlKata.Execution
             int? timeout = null
         )
         {
-
             var multi = await this.GetMultipleAsync<T>(
                 queries,
                 transaction,
@@ -332,14 +326,13 @@ namespace SqlKata.Execution
 
             using (multi)
             {
-                for (var i = 0; i < queries.Count(); i++)
+                for (var i = 0; i < queries.Length; i++)
                 {
                     list.Add(multi.Read<T>());
                 }
             }
 
             return list;
-
         }
 
         public bool Exists(Query query, IDbTransaction transaction = null, int? timeout = null)
@@ -415,6 +408,7 @@ namespace SqlKata.Execution
         {
             return await this.AggregateAsync<T>(query, "avg", new[] { column });
         }
+
         public T Sum<T>(Query query, string column)
         {
             return this.Aggregate<T>(query, "sum", new[] { column });
@@ -439,6 +433,7 @@ namespace SqlKata.Execution
         {
             return this.Aggregate<T>(query, "max", new[] { column });
         }
+
         public async Task<T> MaxAsync<T>(Query query, string column)
         {
             return await this.AggregateAsync<T>(query, "max", new[] { column });
@@ -446,7 +441,6 @@ namespace SqlKata.Execution
 
         public PaginationResult<T> Paginate<T>(Query query, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null)
         {
-
             if (page < 1)
             {
                 throw new ArgumentException("Page param should be greater than or equal to 1", nameof(page));
@@ -478,12 +472,10 @@ namespace SqlKata.Execution
                 Count = count,
                 List = list
             };
-
         }
 
         public async Task<PaginationResult<T>> PaginateAsync<T>(Query query, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null)
         {
-
             if (page < 1)
             {
                 throw new ArgumentException("Page param should be greater than or equal to 1", nameof(page));
@@ -515,7 +507,6 @@ namespace SqlKata.Execution
                 Count = count,
                 List = list
             };
-
         }
 
         public void Chunk<T>(
@@ -523,8 +514,7 @@ namespace SqlKata.Execution
             int chunkSize,
             Func<IEnumerable<T>, int, bool> func,
             IDbTransaction transaction = null,
-            int? timeout = null
-        )
+            int? timeout = null)
         {
             var result = this.Paginate<T>(query, 1, chunkSize, transaction, timeout);
 
@@ -541,7 +531,6 @@ namespace SqlKata.Execution
                     return;
                 }
             }
-
         }
 
         public async Task ChunkAsync<T>(
@@ -567,7 +556,6 @@ namespace SqlKata.Execution
                     return;
                 }
             }
-
         }
 
         public void Chunk<T>(Query query, int chunkSize, Action<IEnumerable<T>, int> action, IDbTransaction transaction = null, int? timeout = null)
@@ -600,7 +588,6 @@ namespace SqlKata.Execution
                 result = result.Next();
                 action(result.List, result.Page);
             }
-
         }
 
         public IEnumerable<T> Select<T>(string sql, object param = null, IDbTransaction transaction = null, int? timeout = null)
@@ -694,7 +681,10 @@ namespace SqlKata.Execution
                         continue;
                     }
 
-                    var children = include.Query.WhereIn(include.ForeignKey, localIds).Get()
+                    var children = include
+                        .Query
+                        .WhereIn(include.ForeignKey, localIds)
+                        .Get()
                         .Cast<IDictionary<string, object>>()
                         .Select(x => new Dictionary<string, object>(x, StringComparer.OrdinalIgnoreCase))
                         .GroupBy(x => x[include.ForeignKey].ToString())
@@ -714,7 +704,8 @@ namespace SqlKata.Execution
                     include.ForeignKey = include.Name + "Id";
                 }
 
-                var foreignIds = dynamicResult.Where(x => x[include.ForeignKey] != null)
+                var foreignIds = dynamicResult
+                    .Where(x => x[include.ForeignKey] != null)
                     .Select(x => x[include.ForeignKey].ToString())
                     .ToList();
 
@@ -723,7 +714,10 @@ namespace SqlKata.Execution
                     continue;
                 }
 
-                var related = include.Query.WhereIn(include.LocalKey, foreignIds).Get()
+                var related = include
+                    .Query
+                    .WhereIn(include.LocalKey, foreignIds)
+                    .Get()
                     .Cast<IDictionary<string, object>>()
                     .Select(x => new Dictionary<string, object>(x, StringComparer.OrdinalIgnoreCase))
                     .ToDictionary(x => x[include.LocalKey].ToString());
@@ -736,7 +730,6 @@ namespace SqlKata.Execution
             }
 
             return dynamicResult.Cast<T>();
-
         }
 
         private static async Task<IEnumerable<T>> handleIncludesAsync<T>(Query query, IEnumerable<T> result)
@@ -760,7 +753,6 @@ namespace SqlKata.Execution
 
             foreach (var include in query.Includes)
             {
-
                 if (include.IsMany)
                 {
                     if (include.ForeignKey == null)
@@ -833,7 +825,6 @@ namespace SqlKata.Execution
 
             return dynamicResult.Cast<T>();
         }
-
 
         /// <summary>
         /// Compile and log query


### PR DESCRIPTION
Now the `values` parameter of `.Insert`, `.Update`, `.Where` & `.Having` accepts any implementation of `IEnumerable<KeyValuePair<string, object>>`, including [`IDictionary<string, object>`](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.idictionary-2) & [`ExpandoObject`](https://docs.microsoft.com/en-us/dotnet/api/system.dynamic.expandoobject).