### PR TITLE
Tuned Wrap method of Compiler class

### DIFF
--- a/QueryBuilder.Tests/SelectTests.cs
+++ b/QueryBuilder.Tests/SelectTests.cs
@@ -679,6 +679,18 @@ namespace SqlKata.Tests
         }
 
         [Fact]
+        public void HavingComplex()
+        {
+            string having = "CASE WHEN Document.DateDue BETWEEN '2020-10-06' AND '9999-12-31' THEN Document.AmountDue ELSE 0 END";
+
+            var q = new Query("Document");
+            q.Having(having, ">", 2000);
+
+            var c = Compile(q);
+            Assert.Equal("SELECT * FROM [Document] HAVING CASE WHEN [Document].[DateDue] BETWEEN '2020-10-06' AND '9999-12-31' THEN [Document].[AmountDue] ELSE 0 END > 2000", c[EngineCodes.SqlServer]);
+        }
+        
+        [Fact]
         public void MultipleHaving()
         {
             var q = new Query("Table1")

--- a/QueryBuilder/Compilers/Compiler.cs
+++ b/QueryBuilder/Compilers/Compiler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace SqlKata.Compilers
 {
@@ -16,6 +17,7 @@ namespace SqlKata.Compilers
         protected virtual string TableAsKeyword { get; set; } = "AS ";
         protected virtual string LastId { get; set; } = "";
         protected virtual string EscapeCharacter { get; set; } = "\\";
+        protected virtual string ReservedKeywords { get; set; } = "ADD|ALL|ALTER|AND|ANY|AS|ASC|AUTHORIZATION|BACKUP|BEGIN|BETWEEN|BREAK|BROWSE|BULK|BY|CASCADE|CASE|CHECK|CHECKPOINT|CLOSE|CLUSTERED|COALESCE|COLLATE|COLUMN|COMMIT|COMPUTE|CONSTRAINT|CONTAINS|CONTAINSTABLE|CONTINUE|CONVERT|CREATE|CROSS|CURRENT|CURRENT_DATE|CURRENT_TIME|CURRENT_TIMESTAMP|CURRENT_USER|CURSOR|DATABASE|DBCC|DEALLOCATE|DECLARE|DEFAULT|DELETE|DENY|DESC|DISK|DISTINCT|DISTRIBUTED|DOUBLE|DROP|DUMP|ELSE|END|ERRLVL|ESCAPE|EXCEPT|EXEC|EXECUTE|EXISTS|EXIT|EXTERNAL|FETCH|FILE|FILLFACTOR|FOR|FOREIGN|FREETEXT|FREETEXTTABLE|FROM|FULL|FUNCTION|GOTO|GRANT|GROUP|HAVING|HOLDLOCK|IDENTITY|IDENTITYCOL|IDENTITY_INSERT|IF|IN|INDEX|INNER|INSERT|INTERSECT|INTO|IS|JOIN|KEY|KILL|LEFT|LIKE|LINENO|LOAD|MERGE|NATIONAL|NOCHECK|NONCLUSTERED|NOT|NULL|NULLIF|OF|OFF|OFFSETS|ON|OPEN|OPENDATASOURCE|OPENQUERY|OPENROWSET|OPENXML|OPTION|OR|ORDER|OUTER|OVER|PERCENT|PIVOT|PLAN|PRECISION|PRIMARY|PRINT|PROC|PROCEDURE|PUBLIC|RAISERROR|READ|READTEXT|RECONFIGURE|REFERENCES|REPLICATION|RESTORE|RESTRICT|RETURN|REVERT|REVOKE|RIGHT|ROLLBACK|ROWCOUNT|ROWGUIDCOL|RULE|SAVE|SCHEMA|SECURITYAUDIT|SELECT|SEMANTICKEYPHRASETABLE|SEMANTICSIMILARITYDETAILSTABLE|SEMANTICSIMILARITYTABLE|SESSION_USER|SET|SETUSER|SHUTDOWN|SOME|STATISTICS|SYSTEM_USER|TABLE|TABLESAMPLE|TEXTSIZE|THEN|TO|TOP|TRAN|TRANSACTION|TRIGGER|TRUNCATE|TRY_CONVERT|TSEQUAL|UNION|UNIQUE|UNPIVOT|UPDATE|UPDATETEXT|USE|USER|VALUES|VARYING|VIEW|WAITFOR|WHEN|WHERE|WHILE|WITH|WITHIN GROUP|WRITETEXT";
 
         protected Compiler()
         {
@@ -799,7 +801,6 @@ namespace SqlKata.Compilers
         /// <returns></returns>
         public virtual string Wrap(string value)
         {
-
             if (value.ToLowerInvariant().Contains(" as "))
             {
                 var index = value.ToLowerInvariant().IndexOf(" as ");
@@ -809,17 +810,24 @@ namespace SqlKata.Compilers
                 return Wrap(before) + $" {ColumnAsKeyword}" + WrapValue(after);
             }
 
-            if (value.Contains("."))
+            //wrap keywords with §
+            value = Regex.Replace(value, @"\b(" + ReservedKeywords + ")\\b", (match) =>
             {
-                return string.Join(".", value.Split('.').Select((x, index) =>
-                {
-                    return WrapValue(x);
-                }));
-            }
+                return $"§{match.Value}§";
+            });
 
-            // If we reach here then the value does not contain an "AS" alias
-            // nor dot "." expression, so wrap it as regular value.
-            return WrapValue(value);
+            //wrap identifiers
+            //finds words delimited by dots or whitespaces or other delimiters
+            value = Regex.Replace(value, @"(?i)\b[a-z_ ]+[a-z0-9_]*\b(?=\.)|(?<=\.)\b[a-z_ ]+[a-z0-9_]*\b|(?<=\s|^|\()*\b[a-z_ ]+[a-z0-9_]*\b(?=\s|,|\)|$)|(?<=\s|^|\()*\b[a-z_\[]+[a-z0-9_\]]*(?=\s|,|\)|$)", (match) =>
+            {
+                return WrapValue(match.Value);
+            });
+
+            //unwrap keywords
+            return Regex.Replace(value, @"§\b(" + ReservedKeywords + ")\\b§", (match) =>
+            {
+                return match.Value.Trim('§');
+            });
         }
 
         /// <summary>


### PR DESCRIPTION
Tuned Wrap method of Compiler class to correctly wrap identifiers in complex where/having clause.
Simple splitting by dots was not good enough for complex where/having clauses (as seen in test included).
I understand, that better way of doing this would be creating whole new mechanism for working with CASE, but it is too complex for me now.