### PR TITLE
WhereDatePart uses ToLowerInvariant()

### DIFF
--- a/QueryBuilder/Base.Where.cs
+++ b/QueryBuilder/Base.Where.cs
@@ -581,7 +581,7 @@ namespace SqlKata
                 Operator = op,
                 Column = column,
                 Value = value,
-                Part = part,
+                Part = part?.ToLowerInvariant(),
                 IsOr = GetOr(),
                 IsNot = GetNot(),
             });

--- a/QueryBuilder/Compilers/OracleCompiler.cs
+++ b/QueryBuilder/Compilers/OracleCompiler.cs
@@ -108,7 +108,7 @@ namespace SqlKata.Compilers
 
             var isDateTime = (condition.Value is DateTime dt);
 
-            switch (condition.Part?.ToLowerInvariant())
+            switch (condition.Part)
             {
                 case "date": // assume YY-MM-DD format
                     if (isDateTime)

--- a/QueryBuilder/Compilers/OracleCompiler.cs
+++ b/QueryBuilder/Compilers/OracleCompiler.cs
@@ -108,7 +108,7 @@ namespace SqlKata.Compilers
 
             var isDateTime = (condition.Value is DateTime dt);
 
-            switch (condition.Part)
+            switch (condition.Part?.ToLowerInvariant())
             {
                 case "date": // assume YY-MM-DD format
                     if (isDateTime)


### PR DESCRIPTION
WhereDatePart must .ToLowerInvariant() the "part" var for later switchs dont miss and produce the default behavior.