### PR TITLE
Use table name when joining with query defining only a `From` clause

### DIFF
--- a/QueryBuilder.Tests/SelectTests.cs
+++ b/QueryBuilder.Tests/SelectTests.cs
@@ -789,5 +789,18 @@ namespace SqlKata.Tests
                     .HavingContains("Column1", @"TestString\%", false, @"\aa");
             });
         }
+
+        [Fact]
+        public void JoinEmptyQuery()
+        {
+            var left = new Query("Table1");
+            var right = new Query("Table2");
+
+            var joined = left.Join(right, join => join.On("Column1", "Column2"));
+
+            var compiled = Compile(joined);
+
+            Assert.Equal("SELECT * FROM \"Table1\" \nINNER JOIN \"Table2\" ON (\"Column1\" = \"Column2\")", compiled[EngineCodes.PostgreSql]);
+        }
     }
 }

--- a/QueryBuilder/Compilers/Compiler.cs
+++ b/QueryBuilder/Compilers/Compiler.cs
@@ -576,6 +576,11 @@ namespace SqlKata.Compilers
             {
                 var fromQuery = queryFromClause.Query;
 
+                if (fromQuery.Clauses.Count == 1 && fromQuery.Clauses[0] is FromClause emptyFromClause)
+                {
+                    return Wrap(emptyFromClause.Table);
+                }
+
                 var alias = string.IsNullOrEmpty(fromQuery.QueryAlias) ? "" : $" {TableAsKeyword}" + WrapValue(fromQuery.QueryAlias);
 
                 var subCtx = CompileSelectQuery(fromQuery);


### PR DESCRIPTION
When passing a `Query` object defining only a `From` clause (`new Query("Table")` or `new Query().From("Table")`) to [`Join`](https://github.com/sqlkata/querybuilder/blob/master/QueryBuilder/Query.Join.cs#L34) the resulting SQL should use the Query's `Table` name instead of generating a `SELECT * FROM [TABLE]` subquery.

Fixes issue #451 (even though the issue was closed, I still do wish the functionality existed).