### PR TITLE
Allow sub queries in inserts alongside parameters

### DIFF
--- a/QueryBuilder.Tests/InsertTests.cs
+++ b/QueryBuilder.Tests/InsertTests.cs
@@ -304,5 +304,111 @@ namespace SqlKata.Tests
                 "INSERT INTO \"TABLE\" (\"NAME\", \"AGE\") VALUES ('The User', '2018-01-01')",
                 c[EngineCodes.Firebird]);
         }
+
+        [Fact]
+        public void InsertMixSingleQueryAndValues()
+        {
+            var columns = new[] {"Name", "Age"};
+            var data = new object[]
+            {
+                "The User",
+                new Query("SomeTable")
+                    .Select("Age")
+                    .Where("Special", 1)
+            };
+
+            var query = new Query("Table")
+                .AsInsert(columns, data);
+
+            var c = Compile(query);
+            var mysql = c[EngineCodes.MySql];
+            
+            Assert.Equal(
+                "INSERT INTO [Table] ([Name], [Age]) VALUES ('The User', (SELECT [Age] FROM [SomeTable] WHERE [Special] = 1))",
+                c[EngineCodes.SqlServer]);
+            
+            Assert.Equal(
+                "INSERT INTO \"TABLE\" (\"NAME\", \"AGE\") VALUES ('The User', (SELECT \"AGE\" FROM \"SOMETABLE\" WHERE \"SPECIAL\" = 1))",
+                c[EngineCodes.Firebird]);
+        }
+        
+        [Fact]
+        public void InsertMixMultipleQueriesAndValues()
+        {
+            var columns = new[] {"Name", "Age", "Gender", "Email"};
+            var data = new object[]
+            {
+                "The User",
+                new Query("SomeTable")
+                    .Select("Age")
+                    .Where("Special", 1),
+                "Male",
+                new Query("AnotherTable")
+                    .Select("Email")
+                    .Join("SomeTable", "SomeTable.Age", "AnotherTable.Age")
+                    .WhereLike("Name", "The User")
+            };
+
+            var query = new Query("Table")
+                .AsInsert(columns, data);
+
+            var c = Compile(query);
+
+            Assert.Equal(
+                "INSERT INTO [Table] ([Name], [Age], [Gender], [Email]) VALUES ('The User', (SELECT [Age] FROM [SomeTable] WHERE [Special] = 1), 'Male', (SELECT [Email] FROM [AnotherTable] \nINNER JOIN [SomeTable] ON [SomeTable].[Age] = [AnotherTable].[Age] WHERE LOWER([Name]) like 'the user'))",
+                c[EngineCodes.SqlServer]);
+        }
+        
+        [Fact]
+        public void InsertAllowMultipleColumnsFromSubQuery()
+        {
+            var columns = new[] {"Name", "Age", "Gender", "Email", "CreatedAt"};
+            var data = new object[]
+            {
+                "The User",
+                new Query("SomeTable")
+                    .Select("Age")
+                    .Where("Special", 1),
+                "Male",
+                new Query("AnotherTable")
+                    .Select("Email", "CreatedAt") // 2 columns
+                    .Join("SomeTable", "SomeTable.Age", "AnotherTable.Age")
+                    .WhereLike("Name", "The User")
+            };
+
+            var query = new Query("Table")
+                .AsInsert(columns, data);
+
+            var c = Compile(query);
+            var mysql = c[EngineCodes.SqlServer];
+            
+            Assert.Equal(
+                "INSERT INTO [Table] ([Name], [Age], [Gender], [Email], [CreatedAt]) VALUES ('The User', (SELECT [Age] FROM [SomeTable] WHERE [Special] = 1), 'Male', (SELECT [Email], [CreatedAt] FROM [AnotherTable] \nINNER JOIN [SomeTable] ON [SomeTable].[Age] = [AnotherTable].[Age] WHERE LOWER([Name]) like 'the user'))",
+                c[EngineCodes.SqlServer]);
+        }
+        
+        [Fact]
+        public void InsertFailIfAmountOfValuesDoesntMatchColumnsWithSubQueries()
+        {
+            var columns = new[] {"Name", "Age", "Gender", "Email"};
+            var data = new object[]
+            {
+                "The User",
+                new Query("SomeTable")
+                    .Select("Age")
+                    .Where("Special", 1),
+                "Male",
+                new Query("AnotherTable")
+                    .Select("Email", "CreatedAt") // 2 columns
+                    .Join("SomeTable", "SomeTable.Age", "AnotherTable.Age")
+                    .WhereLike("Name", "The User")
+            };
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                new Query("Table")
+                    .AsInsert(columns, data);
+            });
+        }
     }
 }

--- a/QueryBuilder/Compilers/Compiler.cs
+++ b/QueryBuilder/Compilers/Compiler.cs
@@ -308,6 +308,28 @@ namespace SqlKata.Compilers
             return ctx;
         }
 
+        protected virtual string CompileInsertClause(SqlResult ctx, InsertClause insertClause)
+        {
+            var valueArray = new string[insertClause.Values.Count];
+            for (var i = 0; i < insertClause.Values.Count; i++)
+            {
+                var value = insertClause.Values[i];
+                if (value is Query valueQuery)
+                {
+                    var subCtx = CompileSelectQuery(valueQuery);
+
+                    valueArray[i] = $"({subCtx.RawSql})";
+                    ctx.Bindings.AddRange(subCtx.Bindings);
+                }
+                else
+                {
+                    valueArray[i] = Parameter(ctx, value);
+                }
+            }
+            
+            return string.Join(", ", valueArray);
+        }
+        
         protected virtual SqlResult CompileInsertQuery(Query query)
         {
             var ctx = new SqlResult
@@ -346,12 +368,11 @@ namespace SqlKata.Compilers
             }
 
             var inserts = ctx.Query.GetComponents<AbstractInsertClause>("insert", EngineCode);
-
             if (inserts[0] is InsertClause insertClause)
             {
                 var columns = string.Join(", ", WrapArray(insertClause.Columns));
-                var values = string.Join(", ", Parameterize(ctx, insertClause.Values));
-
+                var values = CompileInsertClause(ctx, insertClause);
+      
                 ctx.RawSql = $"INSERT INTO {table} ({columns}) VALUES ({values})";
 
                 if (insertClause.ReturnId && !string.IsNullOrEmpty(LastId))
@@ -380,10 +401,9 @@ namespace SqlKata.Compilers
             {
                 foreach (var insert in inserts.GetRange(1, inserts.Count - 1))
                 {
-                    var clause = insert as InsertClause;
+                    var values = CompileInsertClause(ctx, insert as InsertClause);
 
-                    ctx.RawSql += ", (" + string.Join(", ", Parameterize(ctx, clause.Values)) + ")";
-
+                    ctx.RawSql += $", ({values})";
                 }
             }
 

--- a/QueryBuilder/Query.Insert.cs
+++ b/QueryBuilder/Query.Insert.cs
@@ -24,7 +24,23 @@ namespace SqlKata
                 throw new InvalidOperationException($"{nameof(columns)} and {nameof(values)} cannot be null or empty");
             }
 
-            if (columnsList.Count != valuesList.Count)
+            var valuesCount = 0;
+            foreach (var value in valuesList)
+            {
+                if (value is Query query && query.Method == "select")
+                {
+                    if (!(query.Clauses[0] is FromClause)) continue;
+                    
+                    valuesCount += query.Clauses.GetRange(1, query.Clauses.Count - 1)
+                        .OfType<Column>()
+                        .Count();
+                }
+                else
+                {
+                    valuesCount++;
+                }
+            }
+            if (columnsList.Count != valuesCount)
             {
                 throw new InvalidOperationException($"{nameof(columns)} and {nameof(values)} cannot be null or empty");
             }


### PR DESCRIPTION
Allow mixing parameterized insert queries & query inserts.
This is very useful when you have some of the data, but is looking to get the rest of the data directly in the database without having to execute another query in C#, increasing the overall time spent due to the second database round trip.

Example use case
```cs
var discordId = "discord_id_value";
var steamId = "steam_id_value";
var query = new Query("Discord")
    .AsInsert(
        new[] {"Id", "UserId"},
        new object[]
        {
            discordId,
            new Query("User")
                .Select("Id")
                .Where("SteamId", steamId)
        }
    );
```

Which would then compile into 
```sql
INSERT INTO
  [Discord] ([Id], [UserId])
VALUES
  ('discord_id_value', (SELECT [Id] FROM [User] WHERE [SteamId] = 'steam_id_value'))
```