### PR TITLE
 Add support to Transactions using a singleton TransactionWrapper like Laravel QueryBuilder

### DIFF
--- a/Program/Program.cs
+++ b/Program/Program.cs
@@ -34,19 +34,51 @@ namespace Program
 
         static void Main(string[] args)
         {
+            // With Transactions
             using (var db = SqlLiteQueryFactory())
             {
                 var query = db.Query("accounts")
                     .Where("balance", ">", 0)
                     .GroupBy("balance")
-                .Limit(10);
+                    .Where("id", 10)
+                    .Limit(10);
 
                 var accounts = query.Clone().Get();
                 Console.WriteLine(JsonConvert.SerializeObject(accounts, Formatting.Indented));
 
+                db.BeginTransaction();
+
+                var update = db.Query("accounts")
+                    .Where("id", 10)
+                    .Update(new
+                    {
+                        balance = 890 + new Random().Next(1, 1000)
+                    });
+
+                accounts = query.Clone().Get();
+
+                Console.WriteLine(JsonConvert.SerializeObject(accounts, Formatting.Indented));
+
+                db.Rollback();
+
+                accounts = query.Clone().Get();
+
+                Console.WriteLine(JsonConvert.SerializeObject(accounts, Formatting.Indented));
+
+                var exists = query.Clone().Exists();
+
+                Console.WriteLine(exists);
+            }
+
+            // Without Transactions
+            /*
+            using (var db = SqlLiteQueryFactory())
+            {
+                var query = db.Query("accounts")
                 var exists = query.Clone().Exists();
                 Console.WriteLine(exists);
             }
+            */
         }
 
         private static void log(Compiler compiler, Query query)

--- a/SqlKata.Execution/Query.Extensions.cs
+++ b/SqlKata.Execution/Query.Extensions.cs
@@ -9,32 +9,38 @@ namespace SqlKata.Execution
     {
         public static bool Exists(this Query query, IDbTransaction transaction = null, int? timeout = null)
         {
-            return CreateQueryFactory(query).Exists(query, transaction, timeout);
+            var db = CreateQueryFactory(query);
+            return db.Exists(query, db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
-        public async static Task<bool> ExistsAsync(this Query query, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<bool> ExistsAsync(this Query query, IDbTransaction transaction = null, int? timeout = null)
         {
-            return await CreateQueryFactory(query).ExistsAsync(query, transaction, timeout);
+            var db = CreateQueryFactory(query);
+            return await db.ExistsAsync(query, db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static bool NotExist(this Query query, IDbTransaction transaction = null, int? timeout = null)
         {
-            return !CreateQueryFactory(query).Exists(query, transaction, timeout);
+            var db = CreateQueryFactory(query);
+            return !db.Exists(query, db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
-        public async static Task<bool> NotExistAsync(this Query query, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<bool> NotExistAsync(this Query query, IDbTransaction transaction = null, int? timeout = null)
         {
-            return !(await CreateQueryFactory(query).ExistsAsync(query, transaction, timeout));
+            var db = CreateQueryFactory(query);
+            return !(await db.ExistsAsync(query, db.TransactionWrapper.Transaction ?? transaction, timeout));
         }
 
         public static IEnumerable<T> Get<T>(this Query query, IDbTransaction transaction = null, int? timeout = null)
         {
-            return CreateQueryFactory(query).Get<T>(query, transaction, timeout);
+            var db = CreateQueryFactory(query);
+            return db.Get<T>(query, db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static async Task<IEnumerable<T>> GetAsync<T>(this Query query, IDbTransaction transaction = null, int? timeout = null)
         {
-            return await CreateQueryFactory(query).GetAsync<T>(query, transaction, timeout);
+            var db = CreateQueryFactory(query);
+            return await db.GetAsync<T>(query, db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static IEnumerable<dynamic> Get(this Query query, IDbTransaction transaction = null, int? timeout = null)
@@ -49,12 +55,14 @@ namespace SqlKata.Execution
 
         public static T FirstOrDefault<T>(this Query query, IDbTransaction transaction = null, int? timeout = null)
         {
-            return CreateQueryFactory(query).FirstOrDefault<T>(query, transaction, timeout);
+            var db = CreateQueryFactory(query);
+            return db.FirstOrDefault<T>(query, db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static async Task<T> FirstOrDefaultAsync<T>(this Query query, IDbTransaction transaction = null, int? timeout = null)
         {
-            return await CreateQueryFactory(query).FirstOrDefaultAsync<T>(query, transaction, timeout);
+            var db = CreateQueryFactory(query);
+            return await db.FirstOrDefaultAsync<T>(query, db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static dynamic FirstOrDefault(this Query query, IDbTransaction transaction = null, int? timeout = null)
@@ -69,12 +77,14 @@ namespace SqlKata.Execution
 
         public static T First<T>(this Query query, IDbTransaction transaction = null, int? timeout = null)
         {
-            return CreateQueryFactory(query).First<T>(query, transaction, timeout);
+            var db = CreateQueryFactory(query);
+            return db.First<T>(query, db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static async Task<T> FirstAsync<T>(this Query query, IDbTransaction transaction = null, int? timeout = null)
         {
-            return await CreateQueryFactory(query).FirstAsync<T>(query, transaction, timeout);
+            var db = CreateQueryFactory(query);
+            return await db.FirstAsync<T>(query, db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static dynamic First(this Query query, IDbTransaction transaction = null, int? timeout = null)
@@ -91,14 +101,14 @@ namespace SqlKata.Execution
         {
             var db = CreateQueryFactory(query);
 
-            return db.Paginate<T>(query, page, perPage, transaction, timeout);
+            return db.Paginate<T>(query, page, perPage, db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static async Task<PaginationResult<T>> PaginateAsync<T>(this Query query, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null)
         {
             var db = CreateQueryFactory(query);
 
-            return await db.PaginateAsync<T>(query, page, perPage, transaction, timeout);
+            return await db.PaginateAsync<T>(query, page, perPage, db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static PaginationResult<dynamic> Paginate(this Query query, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null)
@@ -115,11 +125,12 @@ namespace SqlKata.Execution
         {
             var db = CreateQueryFactory(query);
 
-            db.Chunk<T>(query, chunkSize, func, transaction, timeout);
+            db.Chunk<T>(query, chunkSize, func, db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
         public static async Task ChunkAsync<T>(this Query query, int chunkSize, Func<IEnumerable<T>, int, bool> func, IDbTransaction transaction = null, int? timeout = null)
         {
-            await CreateQueryFactory(query).ChunkAsync<T>(query, chunkSize, func, transaction, timeout);
+            var db = CreateQueryFactory(query);
+            await db.ChunkAsync<T>(query, chunkSize, func, db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static void Chunk(this Query query, int chunkSize, Func<IEnumerable<dynamic>, int, bool> func, IDbTransaction transaction = null, int? timeout = null)
@@ -135,12 +146,14 @@ namespace SqlKata.Execution
         {
             var db = CreateQueryFactory(query);
 
-            db.Chunk(query, chunkSize, action, transaction, timeout);
+            db.Chunk(query, chunkSize, action, db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static async Task ChunkAsync<T>(this Query query, int chunkSize, Action<IEnumerable<T>, int> action, IDbTransaction transaction = null, int? timeout = null)
         {
-            await CreateQueryFactory(query).ChunkAsync<T>(query, chunkSize, action, transaction, timeout);
+            var db = CreateQueryFactory(query);
+
+            await db.ChunkAsync<T>(query, chunkSize, action, db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static void Chunk(this Query query, int chunkSize, Action<IEnumerable<dynamic>, int> action, IDbTransaction transaction = null, int? timeout = null)
@@ -153,127 +166,142 @@ namespace SqlKata.Execution
             await ChunkAsync<dynamic>(query, chunkSize, action, transaction, timeout);
         }
 
-        public static int Insert(this Query query, IEnumerable<KeyValuePair<string, object>> values, IDbTransaction transaction = null, int? timeout = null)
+        public static int Insert(this Query query, IReadOnlyDictionary<string, object> values, IDbTransaction transaction = null, int? timeout = null)
         {
-            return CreateQueryFactory(query).Execute(query.AsInsert(values), transaction, timeout);
+            var db = CreateQueryFactory(query);
+            return db.Execute(query.AsInsert(values), db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
-        public static async Task<int> InsertAsync(this Query query, IEnumerable<KeyValuePair<string, object>> values, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<int> InsertAsync(this Query query, IReadOnlyDictionary<string, object> values, IDbTransaction transaction = null, int? timeout = null)
         {
-            return await CreateQueryFactory(query).ExecuteAsync(query.AsInsert(values), transaction, timeout);
+            var db = CreateQueryFactory(query);
+            return await db.ExecuteAsync(query.AsInsert(values), db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static int Insert(this Query query, IEnumerable<string> columns, IEnumerable<IEnumerable<object>> valuesCollection, IDbTransaction transaction = null, int? timeout = null)
         {
-            return CreateQueryFactory(query).Execute(query.AsInsert(columns, valuesCollection), transaction, timeout);
+            var db = CreateQueryFactory(query);
+            return db.Execute(query.AsInsert(columns, valuesCollection), db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static int Insert(this Query query, IEnumerable<string> columns, Query fromQuery, IDbTransaction transaction = null, int? timeout = null)
         {
-            return CreateQueryFactory(query).Execute(query.AsInsert(columns, fromQuery), transaction, timeout);
+            var db = CreateQueryFactory(query);
+            return db.Execute(query.AsInsert(columns, fromQuery), db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static async Task<int> InsertAsync(this Query query, IEnumerable<string> columns, Query fromQuery, IDbTransaction transaction = null, int? timeout = null)
         {
-            return await CreateQueryFactory(query).ExecuteAsync(query.AsInsert(columns, fromQuery), transaction, timeout);
+            var db = CreateQueryFactory(query);
+            return await db.ExecuteAsync(query.AsInsert(columns, fromQuery), db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static int Insert(this Query query, object data, IDbTransaction transaction = null, int? timeout = null)
         {
-            return CreateQueryFactory(query).Execute(query.AsInsert(data), transaction, timeout);
+            var db = CreateQueryFactory(query);
+            return db.Execute(query.AsInsert(data), db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static async Task<int> InsertAsync(this Query query, object data, IDbTransaction transaction = null, int? timeout = null)
         {
-            return await CreateQueryFactory(query).ExecuteAsync(query.AsInsert(data), transaction, timeout);
+            var db = CreateQueryFactory(query);
+            return await db.ExecuteAsync(query.AsInsert(data), db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static T InsertGetId<T>(this Query query, object data, IDbTransaction transaction = null, int? timeout = null)
         {
             var db = CreateQueryFactory(query);
 
-            var row = db.First<InsertGetIdRow<T>>(query.AsInsert(data, true), transaction, timeout);
+            var row = db.First<InsertGetIdRow<T>>(query.AsInsert(data, true), db.TransactionWrapper.Transaction ?? transaction, timeout);
 
             return row.Id;
         }
 
         public static async Task<T> InsertGetIdAsync<T>(this Query query, object data, IDbTransaction transaction = null, int? timeout = null)
         {
-            var row = await CreateQueryFactory(query)
-                .FirstAsync<InsertGetIdRow<T>>(query.AsInsert(data, true), transaction, timeout);
+            var db = CreateQueryFactory(query);
+            var row = await db
+                .FirstAsync<InsertGetIdRow<T>>(query.AsInsert(data, true), db.TransactionWrapper.Transaction ?? transaction, timeout);
 
             return row.Id;
         }
 
-        public static T InsertGetId<T>(this Query query, IEnumerable<KeyValuePair<string, object>> data, IDbTransaction transaction = null, int? timeout = null)
+        public static T InsertGetId<T>(this Query query, IReadOnlyDictionary<string, object> data, IDbTransaction transaction = null, int? timeout = null)
         {
-            var row = CreateQueryFactory(query).First<InsertGetIdRow<T>>(query.AsInsert(data, true), transaction, timeout);
+            var db = CreateQueryFactory(query);
+            var row = db.First<InsertGetIdRow<T>>(query.AsInsert(data, true), db.TransactionWrapper.Transaction ?? transaction, timeout);
 
             return row.Id;
         }
 
-        public static async Task<T> InsertGetIdAsync<T>(this Query query, IEnumerable<KeyValuePair<string, object>> data, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<T> InsertGetIdAsync<T>(this Query query, IReadOnlyDictionary<string, object> data, IDbTransaction transaction = null, int? timeout = null)
         {
-            var row = await CreateQueryFactory(query).FirstAsync<InsertGetIdRow<T>>(query.AsInsert(data, true), transaction, timeout);
+            var db = CreateQueryFactory(query);
+            var row = await db.FirstAsync<InsertGetIdRow<T>>(query.AsInsert(data, true), db.TransactionWrapper.Transaction ?? transaction, timeout);
 
             return row.Id;
         }
 
-        public static int Update(this Query query, IEnumerable<KeyValuePair<string, object>> values, IDbTransaction transaction = null, int? timeout = null)
+        public static int Update(this Query query, IReadOnlyDictionary<string, object> values, IDbTransaction transaction = null, int? timeout = null)
         {
-            return CreateQueryFactory(query).Execute(query.AsUpdate(values), transaction, timeout);
+            var db = CreateQueryFactory(query);
+            return db.Execute(query.AsUpdate(values), db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
-        public static async Task<int> UpdateAsync(this Query query, IEnumerable<KeyValuePair<string, object>> values, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<int> UpdateAsync(this Query query, IReadOnlyDictionary<string, object> values, IDbTransaction transaction = null, int? timeout = null)
         {
-            return await CreateQueryFactory(query).ExecuteAsync(query.AsUpdate(values), transaction, timeout);
+            var db = CreateQueryFactory(query);
+            return await db.ExecuteAsync(query.AsUpdate(values), db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static int Update(this Query query, object data, IDbTransaction transaction = null, int? timeout = null)
         {
-            return CreateQueryFactory(query).Execute(query.AsUpdate(data), transaction, timeout);
+            var db = CreateQueryFactory(query);
+            return db.Execute(query.AsUpdate(data), db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static async Task<int> UpdateAsync(this Query query, object data, IDbTransaction transaction = null, int? timeout = null)
         {
-            return await CreateQueryFactory(query).ExecuteAsync(query.AsUpdate(data), transaction, timeout);
+            var db = CreateQueryFactory(query);
+            return await db.ExecuteAsync(query.AsUpdate(data), db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static int Delete(this Query query, IDbTransaction transaction = null, int? timeout = null)
         {
-            return CreateQueryFactory(query).Execute(query.AsDelete(), transaction, timeout);
+            var db = CreateQueryFactory(query);
+            return db.Execute(query.AsDelete(), db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static async Task<int> DeleteAsync(this Query query, IDbTransaction transaction = null, int? timeout = null)
         {
-            return await CreateQueryFactory(query).ExecuteAsync(query.AsDelete(), transaction, timeout);
+            var db = CreateQueryFactory(query);
+            return await db.ExecuteAsync(query.AsDelete(), db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static T Aggregate<T>(this Query query, string aggregateOperation, string[] columns, IDbTransaction transaction = null, int? timeout = null)
         {
             var db = CreateQueryFactory(query);
 
-            return db.ExecuteScalar<T>(query.AsAggregate(aggregateOperation, columns), transaction, timeout);
+            return db.ExecuteScalar<T>(query.AsAggregate(aggregateOperation, columns), db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static async Task<T> AggregateAsync<T>(this Query query, string aggregateOperation, string[] columns, IDbTransaction transaction = null, int? timeout = null)
         {
             var db = CreateQueryFactory(query);
-            return await db.ExecuteScalarAsync<T>(query.AsAggregate(aggregateOperation, columns), transaction, timeout);
+            return await db.ExecuteScalarAsync<T>(query.AsAggregate(aggregateOperation, columns), db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static T Count<T>(this Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null)
         {
             var db = CreateQueryFactory(query);
 
-            return db.ExecuteScalar<T>(query.AsCount(columns), transaction, timeout);
+            return db.ExecuteScalar<T>(query.AsCount(columns), db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static async Task<T> CountAsync<T>(this Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null)
         {
             var db = CreateQueryFactory(query);
-
-            return await db.ExecuteScalarAsync<T>(query.AsCount(columns), transaction, timeout);
+            return await db.ExecuteScalarAsync<T>(query.AsCount(columns), db.TransactionWrapper.Transaction ?? transaction, timeout);
         }
 
         public static T Average<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
@@ -324,15 +352,10 @@ namespace SqlKata.Execution
             {
                 if (method == null)
                 {
-                    throw new InvalidOperationException(
-                        $"Execution methods can only be used with `{nameof(XQuery)}` instances, " +
-                        $"consider using the `{nameof(QueryFactory)}.{nameof(QueryFactory.Query)}()` to create executable queries, " +
-                        $"check https://sqlkata.com/docs/execution/setup#xquery-class for more info");
+                    throw new InvalidOperationException($"Execution methods can only be used with `XQuery` instances, consider using the `QueryFactory.Query()` to create executable queries, check https://sqlkata.com/docs/execution/setup#xquery-class for more info");
                 }
 
-                throw new InvalidOperationException($"The method '{method}()' can only be used with `{nameof(XQuery)}` instances, " +
-                    $"consider using the `{nameof(QueryFactory)}.{nameof(QueryFactory.Query)}()` to create executable queries, " +
-                    $"check https://sqlkata.com/docs/execution/setup#xquery-class for more info");
+                throw new InvalidOperationException($"The method ${method} can only be used with `XQuery` instances, consider using the `QueryFactory.Query()` to create executable queries, check https://sqlkata.com/docs/execution/setup#xquery-class for more info");
             }
 
             return xQuery;
@@ -340,7 +363,7 @@ namespace SqlKata.Execution
 
         internal static QueryFactory CreateQueryFactory(XQuery xQuery)
         {
-            var factory = new QueryFactory(xQuery.Connection, xQuery.Compiler);
+            var factory = new QueryFactory(xQuery.Connection, xQuery.Compiler, QueryFactory.DEFAULT_TIMEOUT, xQuery.TransactionWrapper);
 
             factory.Logger = xQuery.Logger;
 

--- a/SqlKata.Execution/QueryFactory.cs
+++ b/SqlKata.Execution/QueryFactory.cs
@@ -17,20 +17,47 @@ namespace SqlKata.Execution
         public Action<SqlResult> Logger = result => { };
         private bool disposedValue;
 
+        public TransactionWrapper TransactionWrapper { get; set; }
+        
+        public const int DEFAULT_TIMEOUT = 30;
+
+        public void BeginTransaction()
+        {
+            TransactionWrapper.BeginTransaction();
+        }
+
+        public void Rollback()
+        {
+            TransactionWrapper.Rollback();
+        }
+
+        public void Commit()
+        {
+            TransactionWrapper.Commit();
+        }
+
         public int QueryTimeout { get; set; } = 30;
 
         public QueryFactory() { }
 
-        public QueryFactory(IDbConnection connection, Compiler compiler, int timeout = 30)
+        public QueryFactory(IDbConnection connection, Compiler compiler, int timeout = 30, TransactionWrapper transaction = null)
+        //public QueryFactory(IDbConnection connection, Compiler compiler, int timeout = 30)
         {
             Connection = connection;
             Compiler = compiler;
             QueryTimeout = timeout;
+            TransactionWrapper = transaction;
+            
+            if (transaction == null)
+            {
+                TransactionWrapper = new TransactionWrapper(connection, compiler);
+            }
         }
 
         public Query Query()
         {
-            var query = new XQuery(this.Connection, this.Compiler);
+            var query = new XQuery(this.Connection, this.Compiler, this.TransactionWrapper);
+            //var query = new XQuery(this.Connection, this.Compiler);
 
             query.QueryFactory = this;
 
@@ -51,7 +78,8 @@ namespace SqlKata.Execution
         /// <returns></returns>
         public Query FromQuery(Query query)
         {
-            var xQuery = new XQuery(this.Connection, this.Compiler);
+            var xQuery = new XQuery(this.Connection, this.Compiler, this.TransactionWrapper);
+            //var xQuery = new XQuery(this.Connection, this.Compiler);
 
             xQuery.QueryFactory = this;
 

--- a/SqlKata.Execution/TransactionWrapper.cs
+++ b/SqlKata.Execution/TransactionWrapper.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Text;
+using SqlKata.Compilers;
+
+namespace SqlKata
+{
+    public class TransactionWrapper
+    {
+        private IDbConnection Connection { get; set; }
+        private Compiler Compiler { get; set; }
+        public IDbTransaction Transaction { get; set; }
+
+        public TransactionWrapper(IDbConnection connection, Compiler compiler)
+        {
+            this.Connection = connection;
+            this.Compiler = compiler;
+        }
+
+        public void BeginTransaction()
+        {
+            Connection.Open();
+            Transaction = Connection.BeginTransaction();
+        }
+
+        public void Rollback()
+        {
+            Transaction.Rollback();
+            Connection.Close();
+            Transaction.Dispose();
+            Transaction = null;
+        }
+
+        public void Commit()
+        {
+            Transaction.Commit();
+            Connection.Close();
+            Transaction.Dispose();
+            Transaction = null;
+        }
+    }
+}

--- a/SqlKata.Execution/XQuery.cs
+++ b/SqlKata.Execution/XQuery.cs
@@ -11,17 +11,18 @@ namespace SqlKata.Execution
         public Compiler Compiler { get; set; }
         public Action<SqlResult> Logger = result => { };
         public QueryFactory QueryFactory { get; set; }
+        public TransactionWrapper TransactionWrapper { get; set; }
 
-        public XQuery(IDbConnection connection, Compiler compiler)
+        public XQuery(IDbConnection connection, Compiler compiler, TransactionWrapper TransactionWrapper)
         {
             this.Connection = connection;
             this.Compiler = compiler;
+            this.TransactionWrapper = TransactionWrapper;
         }
 
         public override Query Clone()
         {
-
-            var query = new XQuery(this.Connection, this.Compiler);
+            var query = new XQuery(this.Connection, this.Compiler, this.TransactionWrapper);
 
             query.Clauses = this.Clauses.Select(x => x.Clone()).ToList();
             query.Logger = this.Logger;


### PR DESCRIPTION
The following pull request enables a developer to control the transactions using a singleton transactionwrapper without the need to pass the transaction object by parameter to the XQuery call.

This way we avoid the problem of a developer forgetting to pass the transaction object to the XQuery call.

Use it like this:
`db.BeginTransaction();`

// do your insert, updates, deletes

and then use:
`db.Commit() or db.Rollback()`

Both SQLite and SQL Server have been tested successfully

Check Program.cs for an example
