### PR TITLE
Escape parameter place holder

### DIFF
--- a/QueryBuilder.Tests/Firebird/FirebirdLimitTests.cs
+++ b/QueryBuilder.Tests/Firebird/FirebirdLimitTests.cs
@@ -17,7 +17,7 @@ namespace SqlKata.Tests.Firebird
         public void NoLimitNorOffset()
         {
             var query = new Query("Table");
-            var ctx = new SqlResult {Query = query};
+            var ctx = new SqlResult("?",  "\\") {Query = query};
 
             Assert.Null(compiler.CompileLimit(ctx));
         }
@@ -26,7 +26,7 @@ namespace SqlKata.Tests.Firebird
         public void LimitOnly()
         {
             var query = new Query("Table").Limit(10);
-            var ctx = new SqlResult {Query = query};
+            var ctx = new SqlResult("?",  "\\") {Query = query};
 
             Assert.Null(compiler.CompileLimit(ctx));
         }
@@ -35,7 +35,7 @@ namespace SqlKata.Tests.Firebird
         public void OffsetOnly()
         {
             var query = new Query("Table").Offset(20);
-            var ctx = new SqlResult {Query = query};
+            var ctx = new SqlResult("?",  "\\") {Query = query};
 
             Assert.Null(compiler.CompileLimit(ctx));
         }
@@ -44,7 +44,7 @@ namespace SqlKata.Tests.Firebird
         public void LimitAndOffset()
         {
             var query = new Query("Table").Limit(5).Offset(20);
-            var ctx = new SqlResult {Query = query};
+            var ctx = new SqlResult("?",  "\\") {Query = query};
 
             Assert.Equal("ROWS ? TO ?", compiler.CompileLimit(ctx));
             Assert.Equal(21, ctx.Bindings[0]);

--- a/QueryBuilder.Tests/HelperTests.cs
+++ b/QueryBuilder.Tests/HelperTests.cs
@@ -14,7 +14,7 @@ namespace SqlKata.Tests
         [InlineData("   ")]
         public void ItShouldKeepItAsIs(string input)
         {
-            var output = Helper.ReplaceAll(input, "any", x => x + "");
+            var output = Helper.ReplaceAll(input, "any", "\\", x => x + "");
 
             Assert.Equal(input, output);
         }
@@ -28,7 +28,7 @@ namespace SqlKata.Tests
         [InlineData(" ? ? hello", " @ @ hello")]
         public void ReplaceOnTheBegining(string input, string expected)
         {
-            var output = Helper.ReplaceAll(input, "?", x => "@");
+            var output = Helper.ReplaceAll(input, "?", "\\", x => "@");
             Assert.Equal(expected, output);
         }
 
@@ -39,11 +39,13 @@ namespace SqlKata.Tests
         [InlineData("hello ? ?? ? ", "hello @ @@ @ ")]
         public void ReplaceOnTheEnd(string input, string expected)
         {
-            var output = Helper.ReplaceAll(input, "?", x => "@");
+            var output = Helper.ReplaceAll(input, "?", "\\", x => "@");
             Assert.Equal(expected, output);
         }
 
         [Theory]
+        [InlineData("hel\\?o ??? ", "hel\\?o 012 ")]
+        [InlineData("hel\\?o ?? \\?", "hel\\?o 01 \\?")]
         [InlineData("hello?", "hello0")]
         [InlineData("hello? ", "hello0 ")]
         [InlineData("hello??? ", "hello012 ")]
@@ -51,7 +53,7 @@ namespace SqlKata.Tests
         [InlineData("????", "0123")]
         public void ReplaceWithPositions(string input, string expected)
         {
-            var output = Helper.ReplaceAll(input, "?", x => x + "");
+            var output = Helper.ReplaceAll(input, "?", "\\", x => x + "");
             Assert.Equal(expected, output);
         }
 
@@ -220,7 +222,7 @@ namespace SqlKata.Tests
         [Fact]
         public void ExpandParameters()
         {
-            var expanded = Helper.ExpandParameters("where id = ? or id in (?) or id in (?)", "?", new object[] { 1, new[] { 1, 2 }, new object[] { } });
+            var expanded = Helper.ExpandParameters("where id = ? or id in (?) or id in (?)", "?", "\\", new object[] { 1, new[] { 1, 2 }, new object[] { } });
 
             Assert.Equal("where id = ? or id in (?,?) or id in ()", expanded);
         }

--- a/QueryBuilder.Tests/MySql/MySqlLimitTests.cs
+++ b/QueryBuilder.Tests/MySql/MySqlLimitTests.cs
@@ -17,7 +17,7 @@ namespace SqlKata.Tests.MySql
         public void WithNoLimitNorOffset()
         {
             var query = new Query("Table");
-            var ctx = new SqlResult {Query = query};
+            var ctx = new SqlResult("?",  "\\") {Query = query};
 
             Assert.Null(compiler.CompileLimit(ctx));
         }
@@ -26,7 +26,7 @@ namespace SqlKata.Tests.MySql
         public void WithNoOffset()
         {
             var query = new Query("Table").Limit(10);
-            var ctx = new SqlResult {Query = query};
+            var ctx = new SqlResult("?",  "\\") {Query = query};
 
             Assert.Equal("LIMIT ?", compiler.CompileLimit(ctx));
             Assert.Equal(10, ctx.Bindings[0]);
@@ -36,7 +36,7 @@ namespace SqlKata.Tests.MySql
         public void WithNoLimit()
         {
             var query = new Query("Table").Offset(20);
-            var ctx = new SqlResult {Query = query};
+            var ctx = new SqlResult("?",  "\\") {Query = query};
 
             Assert.Equal("LIMIT 18446744073709551615 OFFSET ?", compiler.CompileLimit(ctx));
             Assert.Equal(20, ctx.Bindings[0]);
@@ -47,7 +47,7 @@ namespace SqlKata.Tests.MySql
         public void WithLimitAndOffset()
         {
             var query = new Query("Table").Limit(5).Offset(20);
-            var ctx = new SqlResult {Query = query};
+            var ctx = new SqlResult("?",  "\\") {Query = query};
 
             Assert.Equal("LIMIT ? OFFSET ?", compiler.CompileLimit(ctx));
             Assert.Equal(5, ctx.Bindings[0]);

--- a/QueryBuilder.Tests/Oracle/OracleLegacyLimitTests.cs
+++ b/QueryBuilder.Tests/Oracle/OracleLegacyLimitTests.cs
@@ -21,7 +21,7 @@ namespace SqlKata.Tests.Oracle
         {
             // Arrange:
             var query = new Query(TableName);
-            var ctx = new SqlResult { Query = query, RawSql = SqlPlaceholder };
+            var ctx = new SqlResult("?",  "\\") { Query = query, RawSql = SqlPlaceholder };
 
             // Act:
             compiler.ApplyLegacyLimit(ctx);
@@ -35,7 +35,7 @@ namespace SqlKata.Tests.Oracle
         {
             // Arrange:
             var query = new Query(TableName).Limit(10);
-            var ctx = new SqlResult { Query = query, RawSql = SqlPlaceholder };
+            var ctx = new SqlResult("?",  "\\") { Query = query, RawSql = SqlPlaceholder };
 
             // Act:
             compiler.ApplyLegacyLimit(ctx);
@@ -51,7 +51,7 @@ namespace SqlKata.Tests.Oracle
         {
             // Arrange:
             var query = new Query(TableName).Offset(20);
-            var ctx = new SqlResult { Query = query, RawSql = SqlPlaceholder };
+            var ctx = new SqlResult("?",  "\\") { Query = query, RawSql = SqlPlaceholder };
 
             // Act:
             compiler.ApplyLegacyLimit(ctx);
@@ -67,7 +67,7 @@ namespace SqlKata.Tests.Oracle
         {
             // Arrange:
             var query = new Query(TableName).Limit(5).Offset(20);
-            var ctx = new SqlResult { Query = query, RawSql = SqlPlaceholder };
+            var ctx = new SqlResult("?",  "\\") { Query = query, RawSql = SqlPlaceholder };
 
             // Act:
             compiler.ApplyLegacyLimit(ctx);

--- a/QueryBuilder.Tests/Oracle/OracleLimitTests.cs
+++ b/QueryBuilder.Tests/Oracle/OracleLimitTests.cs
@@ -21,7 +21,7 @@ namespace SqlKata.Tests.Oracle
         {
             // Arrange:
             var query = new Query(TableName);
-            var ctx = new SqlResult { Query = query, RawSql = SqlPlaceholder };
+            var ctx = new SqlResult("?",  "\\") { Query = query, RawSql = SqlPlaceholder };
 
             // Act & Assert:
             Assert.Null(compiler.CompileLimit(ctx));
@@ -32,7 +32,7 @@ namespace SqlKata.Tests.Oracle
         {
             // Arrange:
             var query = new Query(TableName).Limit(10);
-            var ctx = new SqlResult { Query = query, RawSql = SqlPlaceholder };
+            var ctx = new SqlResult("?",  "\\") { Query = query, RawSql = SqlPlaceholder };
 
             //  Act & Assert:
             Assert.EndsWith("OFFSET ? ROWS FETCH NEXT ? ROWS ONLY", compiler.CompileLimit(ctx));
@@ -46,7 +46,7 @@ namespace SqlKata.Tests.Oracle
         {
             // Arrange:
             var query = new Query(TableName).Offset(20);
-            var ctx = new SqlResult { Query = query, RawSql = SqlPlaceholder };
+            var ctx = new SqlResult("?",  "\\") { Query = query, RawSql = SqlPlaceholder };
 
             // Act & Assert:
             Assert.EndsWith("OFFSET ? ROWS", compiler.CompileLimit(ctx));
@@ -60,7 +60,7 @@ namespace SqlKata.Tests.Oracle
         {
             // Arrange:
             var query = new Query(TableName).Limit(5).Offset(20);
-            var ctx = new SqlResult { Query = query, RawSql = SqlPlaceholder };
+            var ctx = new SqlResult("?",  "\\") { Query = query, RawSql = SqlPlaceholder };
 
             // Act & Assert:
             Assert.EndsWith("OFFSET ? ROWS FETCH NEXT ? ROWS ONLY", compiler.CompileLimit(ctx));

--- a/QueryBuilder.Tests/PostgreSql/PostgreSqlLimitTests.cs
+++ b/QueryBuilder.Tests/PostgreSql/PostgreSqlLimitTests.cs
@@ -17,7 +17,7 @@ namespace SqlKata.Tests.PostgreSql
         public void WithNoLimitNorOffset()
         {
             var query = new Query("Table");
-            var ctx = new SqlResult {Query = query};
+            var ctx = new SqlResult("?",  "\\") {Query = query};
 
             Assert.Null(compiler.CompileLimit(ctx));
         }
@@ -26,7 +26,7 @@ namespace SqlKata.Tests.PostgreSql
         public void WithNoOffset()
         {
             var query = new Query("Table").Limit(10);
-            var ctx = new SqlResult {Query = query};
+            var ctx = new SqlResult("?",  "\\") {Query = query};
 
             Assert.Equal("LIMIT ?", compiler.CompileLimit(ctx));
             Assert.Equal(10, ctx.Bindings[0]);
@@ -36,7 +36,7 @@ namespace SqlKata.Tests.PostgreSql
         public void WithNoLimit()
         {
             var query = new Query("Table").Offset(20);
-            var ctx = new SqlResult {Query = query};
+            var ctx = new SqlResult("?",  "\\") {Query = query};
 
             Assert.Equal("OFFSET ?", compiler.CompileLimit(ctx));
             Assert.Equal(20, ctx.Bindings[0]);
@@ -47,7 +47,7 @@ namespace SqlKata.Tests.PostgreSql
         public void WithLimitAndOffset()
         {
             var query = new Query("Table").Limit(5).Offset(20);
-            var ctx = new SqlResult {Query = query};
+            var ctx = new SqlResult("?",  "\\") {Query = query};
 
             Assert.Equal("LIMIT ? OFFSET ?", compiler.CompileLimit(ctx));
             Assert.Equal(5, ctx.Bindings[0]);

--- a/QueryBuilder.Tests/SqlServer/SqlServerLegacyLimitTests.cs
+++ b/QueryBuilder.Tests/SqlServer/SqlServerLegacyLimitTests.cs
@@ -18,7 +18,7 @@ namespace SqlKata.Tests.SqlServer
         public void NoLimitNorOffset()
         {
             var query = new Query("Table");
-            var ctx = new SqlResult {Query = query};
+            var ctx = new SqlResult("?",  "\\") {Query = query};
 
             Assert.Null(compiler.CompileLimit(ctx));
         }
@@ -27,7 +27,7 @@ namespace SqlKata.Tests.SqlServer
         public void LimitOnly()
         {
             var query = new Query("Table").Limit(10);
-            var ctx = new SqlResult {Query = query};
+            var ctx = new SqlResult("?",  "\\") {Query = query};
 
             Assert.Null(compiler.CompileLimit(ctx));
         }
@@ -36,7 +36,7 @@ namespace SqlKata.Tests.SqlServer
         public void OffsetOnly()
         {
             var query = new Query("Table").Offset(20);
-            var ctx = new SqlResult {Query = query};
+            var ctx = new SqlResult("?",  "\\") {Query = query};
 
             Assert.Null(compiler.CompileLimit(ctx));
         }
@@ -45,7 +45,7 @@ namespace SqlKata.Tests.SqlServer
         public void LimitAndOffset()
         {
             var query = new Query("Table").Limit(5).Offset(20);
-            var ctx = new SqlResult {Query = query};
+            var ctx = new SqlResult("?",  "\\") {Query = query};
 
             Assert.Null(compiler.CompileLimit(ctx));
         }

--- a/QueryBuilder.Tests/SqlServer/SqlServerLimitTests.cs
+++ b/QueryBuilder.Tests/SqlServer/SqlServerLimitTests.cs
@@ -18,7 +18,7 @@ namespace SqlKata.Tests.SqlServer
         public void NoLimitNorOffset()
         {
             var query = new Query("Table");
-            var ctx = new SqlResult {Query = query};
+            var ctx = new SqlResult("?",  "\\") {Query = query};
 
             Assert.Null(compiler.CompileLimit(ctx));
         }
@@ -27,7 +27,7 @@ namespace SqlKata.Tests.SqlServer
         public void LimitOnly()
         {
             var query = new Query("Table").Limit(10);
-            var ctx = new SqlResult {Query = query};
+            var ctx = new SqlResult("?",  "\\") {Query = query};
 
             Assert.EndsWith("OFFSET ? ROWS FETCH NEXT ? ROWS ONLY", compiler.CompileLimit(ctx));
             Assert.Equal(2, ctx.Bindings.Count);
@@ -39,7 +39,7 @@ namespace SqlKata.Tests.SqlServer
         public void OffsetOnly()
         {
             var query = new Query("Table").Offset(20);
-            var ctx = new SqlResult {Query = query};
+            var ctx = new SqlResult("?",  "\\") {Query = query};
 
             Assert.EndsWith("OFFSET ? ROWS", compiler.CompileLimit(ctx));
 
@@ -51,7 +51,7 @@ namespace SqlKata.Tests.SqlServer
         public void LimitAndOffset()
         {
             var query = new Query("Table").Limit(5).Offset(20);
-            var ctx = new SqlResult {Query = query};
+            var ctx = new SqlResult("?",  "\\") {Query = query};
 
             Assert.EndsWith("OFFSET ? ROWS FETCH NEXT ? ROWS ONLY", compiler.CompileLimit(ctx));
 

--- a/QueryBuilder.Tests/SqlServer/SqlServerTests.cs
+++ b/QueryBuilder.Tests/SqlServer/SqlServerTests.cs
@@ -22,6 +22,15 @@ namespace SqlKata.Tests.SqlServer
             Assert.Equal("SELECT TOP (@p0) * FROM [table]", result.Sql);
         }
 
+
+        [Fact]
+        public void SqlServerSelectWithParameterPlaceHolder()
+        {
+            var query = new Query("table").Select("Column\\?");
+            var result = compiler.Compile(query);
+            Assert.Equal("SELECT [Column\\?] FROM [table]", result.Sql);
+        }
+
         [Fact]
         public void SqlServerTopWithDistinct()
         {
@@ -42,6 +51,13 @@ namespace SqlKata.Tests.SqlServer
             Assert.Equal("SELECT * FROM [users]", c.ToString());
         }
 
+        [Fact]
+        public void SqlServerSelectWithParameterPlaceHolderEscaped()
+        {
+            var query = new Query("table").Select("Column\\?");
+            var result = compiler.Compile(query);
+            Assert.Equal("SELECT [Column?] FROM [table]", result.ToString());
+        }
 
         [Theory()]
         [InlineData(1)]

--- a/QueryBuilder.Tests/Sqlite/SqliteLimitTests.cs
+++ b/QueryBuilder.Tests/Sqlite/SqliteLimitTests.cs
@@ -17,7 +17,7 @@ namespace SqlKata.Tests.Sqlite
         public void WithNoLimitNorOffset()
         {
             var query = new Query("Table");
-            var ctx = new SqlResult { Query = query };
+            var ctx = new SqlResult("?",  "\\") { Query = query };
 
             Assert.Null(compiler.CompileLimit(ctx));
         }
@@ -26,7 +26,7 @@ namespace SqlKata.Tests.Sqlite
         public void WithNoOffset()
         {
             var query = new Query("Table").Limit(10);
-            var ctx = new SqlResult { Query = query };
+            var ctx = new SqlResult("?",  "\\") { Query = query };
 
             Assert.Equal("LIMIT ?", compiler.CompileLimit(ctx));
             Assert.Equal(10, ctx.Bindings[0]);
@@ -36,7 +36,7 @@ namespace SqlKata.Tests.Sqlite
         public void WithNoLimit()
         {
             var query = new Query("Table").Offset(20);
-            var ctx = new SqlResult { Query = query };
+            var ctx = new SqlResult("?",  "\\") { Query = query };
 
             Assert.Equal("LIMIT -1 OFFSET ?", compiler.CompileLimit(ctx));
             Assert.Equal(20, ctx.Bindings[0]);
@@ -47,7 +47,7 @@ namespace SqlKata.Tests.Sqlite
         public void WithLimitAndOffset()
         {
             var query = new Query("Table").Limit(5).Offset(20);
-            var ctx = new SqlResult { Query = query };
+            var ctx = new SqlResult("?",  "\\") { Query = query };
 
             Assert.Equal("LIMIT ? OFFSET ?", compiler.CompileLimit(ctx));
             Assert.Equal(5, ctx.Bindings[0]);

--- a/QueryBuilder/Compilers/FirebirdCompiler.cs
+++ b/QueryBuilder/Compilers/FirebirdCompiler.cs
@@ -38,7 +38,7 @@ namespace SqlKata.Compilers
                 ctx.Bindings.Add(offset + 1);
                 ctx.Bindings.Add(limit + offset);
 
-                return "ROWS ? TO ?";
+                return $"ROWS {parameterPlaceholder} TO {parameterPlaceholder}";
             }
 
             return null;
@@ -58,7 +58,7 @@ namespace SqlKata.Compilers
 
                 ctx.Query.ClearComponent("limit");
 
-                return "SELECT FIRST ?" + compiled.Substring(6);
+                return $"SELECT FIRST {parameterPlaceholder}" + compiled.Substring(6);
             }
             else if (limit == 0 && offset > 0)
             {
@@ -66,7 +66,7 @@ namespace SqlKata.Compilers
 
                 ctx.Query.ClearComponent("offset");
 
-                return "SELECT SKIP ?" + compiled.Substring(6);
+                return $"SELECT SKIP {parameterPlaceholder}" + compiled.Substring(6);
             }
 
             return compiled;

--- a/QueryBuilder/Compilers/MySqlCompiler.cs
+++ b/QueryBuilder/Compilers/MySqlCompiler.cs
@@ -24,7 +24,7 @@ namespace SqlKata.Compilers
             if (offset == 0)
             {
                 ctx.Bindings.Add(limit);
-                return "LIMIT ?";
+                return $"LIMIT {parameterPlaceholder}";
             }
 
             if (limit == 0)
@@ -34,7 +34,7 @@ namespace SqlKata.Compilers
                 // to avoid this error.
 
                 ctx.Bindings.Add(offset);
-                return "LIMIT 18446744073709551615 OFFSET ?";
+                return $"LIMIT 18446744073709551615 OFFSET {parameterPlaceholder}";
             }
 
             // We have both values
@@ -42,7 +42,7 @@ namespace SqlKata.Compilers
             ctx.Bindings.Add(limit);
             ctx.Bindings.Add(offset);
 
-            return "LIMIT ? OFFSET ?";
+            return $"LIMIT {parameterPlaceholder} OFFSET {parameterPlaceholder}";
 
         }
     }

--- a/QueryBuilder/Compilers/OracleCompiler.cs
+++ b/QueryBuilder/Compilers/OracleCompiler.cs
@@ -57,13 +57,13 @@ namespace SqlKata.Compilers
             if (limit == 0)
             {
                 ctx.Bindings.Add(offset);
-                return $"{safeOrder}OFFSET ? ROWS";
+                return $"{safeOrder}OFFSET {parameterPlaceholder} ROWS";
             }
 
             ctx.Bindings.Add(offset);
             ctx.Bindings.Add(limit);
 
-            return $"{safeOrder}OFFSET ? ROWS FETCH NEXT ? ROWS ONLY";
+            return $"{safeOrder}OFFSET {parameterPlaceholder} ROWS FETCH NEXT {parameterPlaceholder} ROWS ONLY";
         }
 
         internal void ApplyLegacyLimit(SqlResult ctx)
@@ -79,17 +79,17 @@ namespace SqlKata.Compilers
             string newSql;
             if (limit == 0)
             {
-                newSql = $"SELECT * FROM (SELECT \"results_wrapper\".*, ROWNUM \"row_num\" FROM ({ctx.RawSql}) \"results_wrapper\") WHERE \"row_num\" > ?";
+                newSql = $"SELECT * FROM (SELECT \"results_wrapper\".*, ROWNUM \"row_num\" FROM ({ctx.RawSql}) \"results_wrapper\") WHERE \"row_num\" > {parameterPlaceholder}";
                 ctx.Bindings.Add(offset);
             }
             else if (offset == 0)
             {
-                newSql = $"SELECT * FROM ({ctx.RawSql}) WHERE ROWNUM <= ?";
+                newSql = $"SELECT * FROM ({ctx.RawSql}) WHERE ROWNUM <= {parameterPlaceholder}";
                 ctx.Bindings.Add(limit);
             }
             else
             {
-                newSql = $"SELECT * FROM (SELECT \"results_wrapper\".*, ROWNUM \"row_num\" FROM ({ctx.RawSql}) \"results_wrapper\" WHERE ROWNUM <= ?) WHERE \"row_num\" > ?";
+                newSql = $"SELECT * FROM (SELECT \"results_wrapper\".*, ROWNUM \"row_num\" FROM ({ctx.RawSql}) \"results_wrapper\" WHERE ROWNUM <= {parameterPlaceholder}) WHERE \"row_num\" > {parameterPlaceholder}";
                 ctx.Bindings.Add(limit + offset);
                 ctx.Bindings.Add(offset);
             }

--- a/QueryBuilder/Compilers/SqlServerCompiler.cs
+++ b/QueryBuilder/Compilers/SqlServerCompiler.cs
@@ -21,7 +21,7 @@ namespace SqlKata.Compilers
 
             query = query.Clone();
 
-            var ctx = new SqlResult
+            var ctx = new SqlResult(parameterPlaceholder, EscapeCharacter)
             {
                 Query = query,
             };
@@ -46,12 +46,12 @@ namespace SqlKata.Compilers
 
             if (limit == 0)
             {
-                result.RawSql = $"SELECT * FROM ({result.RawSql}) AS [results_wrapper] WHERE [row_num] >= ?";
+                result.RawSql = $"SELECT * FROM ({result.RawSql}) AS [results_wrapper] WHERE [row_num] >= {parameterPlaceholder}";
                 result.Bindings.Add(offset + 1);
             }
             else
             {
-                result.RawSql = $"SELECT * FROM ({result.RawSql}) AS [results_wrapper] WHERE [row_num] BETWEEN ? AND ?";
+                result.RawSql = $"SELECT * FROM ({result.RawSql}) AS [results_wrapper] WHERE [row_num] BETWEEN {parameterPlaceholder} AND {parameterPlaceholder}";
                 result.Bindings.Add(offset + 1);
                 result.Bindings.Add(limit + offset);
             }
@@ -84,10 +84,10 @@ namespace SqlKata.Compilers
                 // handle distinct
                 if (compiled.IndexOf("SELECT DISTINCT") == 0)
                 {
-                    return "SELECT DISTINCT TOP (?)" + compiled.Substring(15);
+                    return $"SELECT DISTINCT TOP ({parameterPlaceholder})" + compiled.Substring(15);
                 }
 
-                return "SELECT TOP (?)" + compiled.Substring(6);
+                return $"SELECT TOP ({parameterPlaceholder})" + compiled.Substring(6);
             }
 
             return compiled;
@@ -119,13 +119,13 @@ namespace SqlKata.Compilers
             if (limit == 0)
             {
                 ctx.Bindings.Add(offset);
-                return $"{safeOrder}OFFSET ? ROWS";
+                return $"{safeOrder}OFFSET {parameterPlaceholder} ROWS";
             }
 
             ctx.Bindings.Add(offset);
             ctx.Bindings.Add(limit);
 
-            return $"{safeOrder}OFFSET ? ROWS FETCH NEXT ? ROWS ONLY";
+            return $"{safeOrder}OFFSET {parameterPlaceholder} ROWS FETCH NEXT {parameterPlaceholder} ROWS ONLY";
         }
 
         public override string CompileRandom(string seed)

--- a/QueryBuilder/Compilers/SqliteCompiler.cs
+++ b/QueryBuilder/Compilers/SqliteCompiler.cs
@@ -31,7 +31,7 @@ namespace SqlKata.Compilers
             if (limit == 0 && offset > 0)
             {
                 ctx.Bindings.Add(offset);
-                return "LIMIT -1 OFFSET ?";
+                return $"LIMIT -1 OFFSET {parameterPlaceholder}";
             }
 
             return base.CompileLimit(ctx);

--- a/QueryBuilder/SqlResult.cs
+++ b/QueryBuilder/SqlResult.cs
@@ -8,6 +8,13 @@ namespace SqlKata
 {
     public class SqlResult
     {
+        private string ParameterPlaceholder { get; set; }
+        private string EscapeCharacter { get; set; }
+        public SqlResult(string parameterPlaceholder, string escapeCharacter)
+        {
+            ParameterPlaceholder = parameterPlaceholder;
+            EscapeCharacter = escapeCharacter;
+        }
         public Query Query { get; set; }
         public string RawSql { get; set; } = "";
         public List<object> Bindings { get; set; } = new List<object>();
@@ -30,7 +37,7 @@ namespace SqlKata
         {
             var deepParameters = Helper.Flatten(Bindings).ToList();
 
-            return Helper.ReplaceAll(RawSql, "?", i =>
+            var subject = Helper.ReplaceAll(RawSql, ParameterPlaceholder, EscapeCharacter, i =>
             {
                 if (i >= deepParameters.Count)
                 {
@@ -41,6 +48,8 @@ namespace SqlKata
                 var value = deepParameters[i];
                 return ChangeToSqlValue(value);
             });
+
+            return Helper.RemoveEscapeCharacter(subject, ParameterPlaceholder, EscapeCharacter);
         }
 
         private string ChangeToSqlValue(object value)


### PR DESCRIPTION
Provides the feasibility to have parameter placeholder in the select statement by escaping them. This also provides the capability to override the parameter placeholder and escape character.

Ex => var query = new Query("table").Select("Column\\?");
produces => SELECT [Column?] FROM [table]
[https://github.com/sqlkata/querybuilder/issues/461](url)