### PR TITLE
Make sure that tests use a predictable time zone.

### DIFF
--- a/QueryBuilder.Tests/InsertTests.cs
+++ b/QueryBuilder.Tests/InsertTests.cs
@@ -37,7 +37,7 @@ namespace SqlKata.Tests
                     new
                     {
                         Name = "The User",
-                        Age = new DateTime(2018, 1, 1),
+                        Age = new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc),
                     });
 
             var c = Compile(query);
@@ -186,7 +186,7 @@ namespace SqlKata.Tests
                     new
                     {
                         Name = "The User",
-                        Age = new DateTime(2018, 1, 1),
+                        Age = new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc),
                     });
 
             var c = Compile(query);
@@ -205,7 +205,7 @@ namespace SqlKata.Tests
                     new
                     {
                         Name = "The User",
-                        Age = new DateTime(2018, 1, 1),
+                        Age = new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc),
                     });
 
             Assert.Throws<InvalidOperationException>(() =>
@@ -220,7 +220,7 @@ namespace SqlKata.Tests
             var dictionaryUser = new Dictionary<string, object>
                 {
                     { "Name", "The User" },
-                    { "Age",  new DateTime(2018, 1, 1) },
+                    { "Age",  new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
                 }
                 .ToArray();
 
@@ -243,7 +243,7 @@ namespace SqlKata.Tests
         {
             var dictionaryUser = new Dictionary<string, object> {
                 { "Name", "The User" },
-                { "Age",  new DateTime(2018, 1, 1) },
+                { "Age",  new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
             };
 
             var query = new Query("Table")
@@ -267,7 +267,7 @@ namespace SqlKata.Tests
                 new Dictionary<string, object>
                 {
                     { "Name", "The User" },
-                    { "Age",  new DateTime(2018, 1, 1) },
+                    { "Age",  new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
                 });
 
             var query = new Query("Table")
@@ -289,7 +289,7 @@ namespace SqlKata.Tests
         {
             dynamic expandoUser = new ExpandoObject();
             expandoUser.Name = "The User";
-            expandoUser.Age = new DateTime(2018, 1, 1);
+            expandoUser.Age = new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
             var query = new Query("Table")
                 .AsInsert(expandoUser);

--- a/QueryBuilder.Tests/ParameterTypeTests.cs
+++ b/QueryBuilder.Tests/ParameterTypeTests.cs
@@ -27,7 +27,7 @@ namespace SqlKata.Tests
                 new object[] {Convert.ToSingle("-2.8", CultureInfo.InvariantCulture).ToString(), -2.8},
                 new object[] {"true", true},
                 new object[] {"false", false},
-                new object[] {"'2018-10-28 19:22:00'", new DateTime(2018, 10, 28, 19, 22, 0)},
+                new object[] {"'2018-10-28 19:22:00'", new DateTime(2018, 10, 28, 19, 22, 0, DateTimeKind.Utc)},
                 new object[] {"0 /* First */", EnumExample.First},
                 new object[] {"1 /* Second */", EnumExample.Second},
                 new object[] {"'a string'", "a string"},

--- a/QueryBuilder.Tests/UpdateTests.cs
+++ b/QueryBuilder.Tests/UpdateTests.cs
@@ -61,7 +61,7 @@ namespace SqlKata.Tests
             var query = new Query("Table").AsUpdate(new
             {
                 Name = "The User",
-                Age = new DateTime(2018, 1, 1),
+                Age = new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc),
             });
 
             var c = Compile(query);
@@ -215,7 +215,7 @@ namespace SqlKata.Tests
             var dictionaryUser = new Dictionary<string, object>
                 {
                     { "Name", "The User" },
-                    { "Age",  new DateTime(2018, 1, 1) },
+                    { "Age",  new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
                 }
                 .ToArray();
 
@@ -234,7 +234,7 @@ namespace SqlKata.Tests
         {
             var dictionaryUser = new Dictionary<string, object> {
                 { "Name", "The User" },
-                { "Age",  new DateTime(2018, 1, 1) },
+                { "Age",  new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
             };
 
             var query = new Query("Table")
@@ -254,7 +254,7 @@ namespace SqlKata.Tests
                 new Dictionary<string, object>
                 {
                     { "Name", "The User" },
-                    { "Age",  new DateTime(2018, 1, 1) },
+                    { "Age",  new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
                 });
 
             var query = new Query("Table")
@@ -272,7 +272,7 @@ namespace SqlKata.Tests
         {
             dynamic expandoUser = new ExpandoObject();
             expandoUser.Name = "The User";
-            expandoUser.Age = new DateTime(2018, 1, 1);
+            expandoUser.Age = new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
             var query = new Query("Table")
                 .AsUpdate(expandoUser);


### PR DESCRIPTION
This makes sure that all tests always use the UTC time zone when constructing a `DateTime`. This doesn't change the existing tests, but it allows us to reject all 'unpredictable' times in our custom (downstream) Snowflake compiler.

This is an example of a change which is needed only for our custom compiler, but which we wouldn't want to keep in a local change on our repository for maintainability reasons. I.e. keeping this as a commit local to our downstream branch would be a constant source of potential merge conflicts, so we would like to upstream this. We'd like to use this as opportunity to discuss how to best handle such changes.