### PR TITLE
Allow multiple aggregated columns per query

### DIFF
--- a/QueryBuilder.Tests/AggregateTests.cs
+++ b/QueryBuilder.Tests/AggregateTests.cs
@@ -107,6 +107,57 @@ namespace SqlKata.Tests
         }
 
         [Fact]
+        public void AggregatesCanHaveALimit()
+        {
+            var query = new Query()
+                .SelectMin("ColumnA", "MinValue")
+                .SelectMax("ColumnB", "MaxValue")
+                .From("Table")
+                .Limit(100)
+                ;
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT TOP (100) MIN([ColumnA]) AS [MinValue], MAX([ColumnB]) AS [MaxValue] FROM [Table]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT FIRST 100 MIN(\"COLUMNA\") AS \"MINVALUE\", MAX(\"COLUMNB\") AS \"MAXVALUE\" FROM \"TABLE\"", c[EngineCodes.Firebird]);
+            Assert.Equal("SELECT MIN(`ColumnA`) AS `MinValue`, MAX(`ColumnB`) AS `MaxValue` FROM `Table` LIMIT 100", c[EngineCodes.MySql]);
+        }
+
+        [Fact]
+        public void AggregatesCanHaveAnOrderBy()
+        {
+            var query = new Query()
+                .SelectMin("ColumnA", "MinValue")
+                .SelectMax("ColumnB", "MaxValue")
+                .From("Table")
+                .OrderBy("MinValue")
+                ;
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT MIN([ColumnA]) AS [MinValue], MAX([ColumnB]) AS [MaxValue] FROM [Table] ORDER BY [MinValue]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT MIN(\"COLUMNA\") AS \"MINVALUE\", MAX(\"COLUMNB\") AS \"MAXVALUE\" FROM \"TABLE\" ORDER BY \"MINVALUE\"", c[EngineCodes.Firebird]);
+            Assert.Equal("SELECT MIN(`ColumnA`) AS `MinValue`, MAX(`ColumnB`) AS `MaxValue` FROM `Table` ORDER BY `MinValue`", c[EngineCodes.MySql]);
+        }
+
+        [Fact]
+        public void AggregatesCanHaveAGroupBy()
+        {
+            var query = new Query()
+                .SelectMin("ColumnA", "MinValue")
+                .SelectMax("ColumnB", "MaxValue")
+                .From("Table")
+                .GroupBy("MinValue")
+                ;
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT MIN([ColumnA]) AS [MinValue], MAX([ColumnB]) AS [MaxValue] FROM [Table] GROUP BY [MinValue]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT MIN(\"COLUMNA\") AS \"MINVALUE\", MAX(\"COLUMNB\") AS \"MAXVALUE\" FROM \"TABLE\" GROUP BY \"MINVALUE\"", c[EngineCodes.Firebird]);
+            Assert.Equal("SELECT MIN(`ColumnA`) AS `MinValue`, MAX(`ColumnB`) AS `MaxValue` FROM `Table` GROUP BY `MinValue`", c[EngineCodes.MySql]);
+        }
+
+        [Fact]
         public void SelectCount()
         {
             var query = new Query("A").SelectCount();

--- a/QueryBuilder.Tests/AggregateTests.cs
+++ b/QueryBuilder.Tests/AggregateTests.cs
@@ -8,15 +8,15 @@ namespace SqlKata.Tests
     public class AggregateTests : TestSupport
     {
         [Fact]
-        public void AggregateAsEmpty()
+        public void SelectAggregateEmpty()
         {
-            Assert.Throws<ArgumentException>(() => new Query("A").AggregateAs("aggregate", new string[] { }));
+            Assert.Throws<ArgumentException>(() => new Query("A").SelectAggregate("aggregate", new string[] { }));
         }
 
         [Fact]
-        public void AggregateAs()
+        public void SelectAggregate()
         {
-            var query = new Query("A").AggregateAs("aggregate", new[] { "Column" });
+            var query = new Query("A").SelectAggregate("aggregate", new[] { "Column" });
 
             var c = Compile(query);
 
@@ -27,9 +27,9 @@ namespace SqlKata.Tests
         }
 
         [Fact]
-        public void AggregateAsAlias()
+        public void SelectAggregateAlias()
         {
-            var query = new Query("A").AggregateAs("aggregate", new[] { "Column" }, "Alias");
+            var query = new Query("A").SelectAggregate("aggregate", new[] { "Column" }, "Alias");
 
             var c = Compile(query);
 
@@ -40,9 +40,9 @@ namespace SqlKata.Tests
         }
 
         [Fact]
-        public void AggregateAsMultipleColumns()
+        public void SelectAggregateMultipleColumns()
         {
-            var query = new Query("A").AggregateAs("aggregate", new[] { "Column1", "Column2" });
+            var query = new Query("A").SelectAggregate("aggregate", new[] { "Column1", "Column2" });
 
             var c = Compile(query);
 
@@ -53,9 +53,9 @@ namespace SqlKata.Tests
         }
 
         [Fact]
-        public void AggregateAsMultipleColumnsAlias()
+        public void SelectAggregateMultipleColumnsAlias()
         {
-            var query = new Query("A").AggregateAs("aggregate", new[] { "Column1", "Column2" }, "Alias");
+            var query = new Query("A").SelectAggregate("aggregate", new[] { "Column1", "Column2" }, "Alias");
 
             var c = Compile(query);
 
@@ -66,9 +66,9 @@ namespace SqlKata.Tests
         }
 
         [Fact]
-        public void CountAs()
+        public void SelectCount()
         {
-            var query = new Query("A").CountAs();
+            var query = new Query("A").SelectCount();
 
             var c = Compile(query);
 
@@ -79,9 +79,9 @@ namespace SqlKata.Tests
         }
 
         [Fact]
-        public void CountAsStarAlias()
+        public void SelectCountStarAlias()
         {
-            var query = new Query("A").CountAs("*", "Alias");
+            var query = new Query("A").SelectCount("*", "Alias");
 
             var c = Compile(query);
 
@@ -92,9 +92,9 @@ namespace SqlKata.Tests
         }
 
         [Fact]
-        public void CountAsColumnAlias()
+        public void SelectCountColumnAlias()
         {
-            var query = new Query("A").CountAs("Column", "Alias");
+            var query = new Query("A").SelectCount("Column", "Alias");
 
             var c = Compile(query);
 
@@ -105,17 +105,17 @@ namespace SqlKata.Tests
         }
 
         [Fact]
-        public void CountAsDoesntModifyColumns()
+        public void SelectCountDoesntModifyColumns()
         {
             {
                 var columns = new string[] { };
-                var query = new Query("A").CountAs(columns);
+                var query = new Query("A").SelectCount(columns);
                 Compile(query);
                 Assert.Equal(columns, new string[] { });
             }
             {
                 var columns = new[] { "ColumnA", "ColumnB" };
-                var query = new Query("A").CountAs(columns);
+                var query = new Query("A").SelectCount(columns);
                 Compile(query);
                 Assert.Equal(columns, new[] { "ColumnA", "ColumnB" });
             }
@@ -124,7 +124,7 @@ namespace SqlKata.Tests
         [Fact]
         public void CountMultipleColumns()
         {
-            var query = new Query("A").CountAs(new[] { "ColumnA", "ColumnB" });
+            var query = new Query("A").SelectCount(new[] { "ColumnA", "ColumnB" });
 
             var c = Compile(query);
 
@@ -132,9 +132,9 @@ namespace SqlKata.Tests
         }
 
         [Fact]
-        public void CountAsMultipleColumns()
+        public void SelectCountMultipleColumns()
         {
-            var query = new Query("A").CountAs(new[] { "ColumnA", "ColumnB" }, "Alias");
+            var query = new Query("A").SelectCount(new[] { "ColumnA", "ColumnB" }, "Alias");
 
             var c = Compile(query);
 
@@ -144,7 +144,7 @@ namespace SqlKata.Tests
         [Fact]
         public void DistinctCount()
         {
-            var query = new Query("A").Distinct().CountAs();
+            var query = new Query("A").Distinct().SelectCount();
 
             var c = Compile(query);
 
@@ -154,7 +154,7 @@ namespace SqlKata.Tests
         [Fact]
         public void DistinctCountMultipleColumns()
         {
-            var query = new Query("A").Distinct().CountAs(new[] { "ColumnA", "ColumnB" });
+            var query = new Query("A").Distinct().SelectCount(new[] { "ColumnA", "ColumnB" });
 
             var c = Compile(query);
 
@@ -164,7 +164,7 @@ namespace SqlKata.Tests
         [Fact]
         public void Average()
         {
-            var query = new Query("A").AverageAs("TTL");
+            var query = new Query("A").SelectAverage("TTL");
 
             var c = Compile(query);
 
@@ -174,7 +174,7 @@ namespace SqlKata.Tests
         [Fact]
         public void AverageAlias()
         {
-            var query = new Query("A").AverageAs("TTL", "Alias");
+            var query = new Query("A").SelectAverage("TTL", "Alias");
 
             var c = Compile(query);
 
@@ -184,7 +184,7 @@ namespace SqlKata.Tests
         [Fact]
         public void Sum()
         {
-            var query = new Query("A").SumAs("PacketsDropped");
+            var query = new Query("A").SelectSum("PacketsDropped");
 
             var c = Compile(query);
 
@@ -194,7 +194,7 @@ namespace SqlKata.Tests
         [Fact]
         public void SumAlias()
         {
-            var query = new Query("A").SumAs("PacketsDropped", "Alias");
+            var query = new Query("A").SelectSum("PacketsDropped", "Alias");
 
             var c = Compile(query);
 
@@ -204,7 +204,7 @@ namespace SqlKata.Tests
         [Fact]
         public void Max()
         {
-            var query = new Query("A").MaxAs("LatencyMs");
+            var query = new Query("A").SelectMax("LatencyMs");
 
             var c = Compile(query);
 
@@ -214,7 +214,7 @@ namespace SqlKata.Tests
         [Fact]
         public void MaxAlias()
         {
-            var query = new Query("A").MaxAs("LatencyMs", "Alias");
+            var query = new Query("A").SelectMax("LatencyMs", "Alias");
 
             var c = Compile(query);
 
@@ -224,7 +224,7 @@ namespace SqlKata.Tests
         [Fact]
         public void Min()
         {
-            var query = new Query("A").MinAs("LatencyMs");
+            var query = new Query("A").SelectMin("LatencyMs");
 
             var c = Compile(query);
 
@@ -234,7 +234,7 @@ namespace SqlKata.Tests
         [Fact]
         public void MinAlias()
         {
-            var query = new Query("A").MinAs("LatencyMs", "Alias");
+            var query = new Query("A").SelectMin("LatencyMs", "Alias");
 
             var c = Compile(query);
 

--- a/QueryBuilder.Tests/AggregateTests.cs
+++ b/QueryBuilder.Tests/AggregateTests.cs
@@ -56,6 +56,57 @@ namespace SqlKata.Tests
         }
 
         [Fact]
+        public void MultipleAggregatesPerQuery()
+        {
+            var query = new Query()
+                .SelectMin("MinColumn")
+                .SelectMax("MaxColumn")
+                .From("Table")
+                ;
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT MIN([MinColumn]) AS [min], MAX([MaxColumn]) AS [max] FROM [Table]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT MIN(`MinColumn`) AS `min`, MAX(`MaxColumn`) AS `max` FROM `Table`", c[EngineCodes.MySql]);
+            Assert.Equal("SELECT MIN(\"MINCOLUMN\") AS \"MIN\", MAX(\"MAXCOLUMN\") AS \"MAX\" FROM \"TABLE\"", c[EngineCodes.Firebird]);
+            Assert.Equal("SELECT MIN(\"MinColumn\") AS \"min\", MAX(\"MaxColumn\") AS \"max\" FROM \"Table\"", c[EngineCodes.PostgreSql]);
+        }
+
+        [Fact]
+        public void AggregatesAndNonAggregatesCanBeMixedInQueries1()
+        {
+            var query = new Query()
+                .Select("ColumnA")
+                .SelectMax("ColumnB")
+                .From("Table")
+                ;
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT [ColumnA], MAX([ColumnB]) AS [max] FROM [Table]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT `ColumnA`, MAX(`ColumnB`) AS `max` FROM `Table`", c[EngineCodes.MySql]);
+            Assert.Equal("SELECT \"COLUMNA\", MAX(\"COLUMNB\") AS \"MAX\" FROM \"TABLE\"", c[EngineCodes.Firebird]);
+            Assert.Equal("SELECT \"ColumnA\", MAX(\"ColumnB\") AS \"max\" FROM \"Table\"", c[EngineCodes.PostgreSql]);
+        }
+
+        [Fact]
+        public void AggregatesAndNonAggregatesCanBeMixedInQueries2()
+        {
+            var query = new Query()
+                .SelectMax("ColumnA")
+                .Select("ColumnB")
+                .From("Table")
+                ;
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT MAX([ColumnA]) AS [max], [ColumnB] FROM [Table]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT MAX(`ColumnA`) AS `max`, `ColumnB` FROM `Table`", c[EngineCodes.MySql]);
+            Assert.Equal("SELECT MAX(\"COLUMNA\") AS \"MAX\", \"COLUMNB\" FROM \"TABLE\"", c[EngineCodes.Firebird]);
+            Assert.Equal("SELECT MAX(\"ColumnA\") AS \"max\", \"ColumnB\" FROM \"Table\"", c[EngineCodes.PostgreSql]);
+        }
+
+        [Fact]
         public void SelectCount()
         {
             var query = new Query("A").SelectCount();

--- a/QueryBuilder.Tests/AggregateTests.cs
+++ b/QueryBuilder.Tests/AggregateTests.cs
@@ -42,27 +42,17 @@ namespace SqlKata.Tests
         [Fact]
         public void SelectAggregateMultipleColumns()
         {
-            var query = new Query("A").SelectAggregate("aggregate", new[] { "Column1", "Column2" });
-
-            var c = Compile(query);
-
-            Assert.Equal("SELECT AGGREGATE(*) AS [aggregate] FROM (SELECT 1 FROM [A] WHERE [Column1] IS NOT NULL AND [Column2] IS NOT NULL) AS [AggregateQuery]", c[EngineCodes.SqlServer]);
-            Assert.Equal("SELECT AGGREGATE(*) AS `aggregate` FROM (SELECT 1 FROM `A` WHERE `Column1` IS NOT NULL AND `Column2` IS NOT NULL) AS `AggregateQuery`", c[EngineCodes.MySql]);
-            Assert.Equal("SELECT AGGREGATE(*) AS \"AGGREGATE\" FROM (SELECT 1 FROM \"A\" WHERE \"COLUMN1\" IS NOT NULL AND \"COLUMN2\" IS NOT NULL) AS \"AGGREGATEQUERY\"", c[EngineCodes.Firebird]);
-            Assert.Equal("SELECT AGGREGATE(*) AS \"aggregate\" FROM (SELECT 1 FROM \"A\" WHERE \"Column1\" IS NOT NULL AND \"Column2\" IS NOT NULL) AS \"AggregateQuery\"", c[EngineCodes.PostgreSql]);
+            Assert.Throws<ArgumentException>(() =>
+                new Query("A").SelectAggregate("aggregate", new[] { "Column1", "Column2" })
+            );
         }
 
         [Fact]
         public void SelectAggregateMultipleColumnsAlias()
         {
-            var query = new Query("A").SelectAggregate("aggregate", new[] { "Column1", "Column2" }, "Alias");
-
-            var c = Compile(query);
-
-            Assert.Equal("SELECT AGGREGATE(*) AS [Alias] FROM (SELECT 1 FROM [A] WHERE [Column1] IS NOT NULL AND [Column2] IS NOT NULL) AS [AliasAggregateQuery]", c[EngineCodes.SqlServer]);
-            Assert.Equal("SELECT AGGREGATE(*) AS `Alias` FROM (SELECT 1 FROM `A` WHERE `Column1` IS NOT NULL AND `Column2` IS NOT NULL) AS `AliasAggregateQuery`", c[EngineCodes.MySql]);
-            Assert.Equal("SELECT AGGREGATE(*) AS \"ALIAS\" FROM (SELECT 1 FROM \"A\" WHERE \"COLUMN1\" IS NOT NULL AND \"COLUMN2\" IS NOT NULL) AS \"ALIASAGGREGATEQUERY\"", c[EngineCodes.Firebird]);
-            Assert.Equal("SELECT AGGREGATE(*) AS \"Alias\" FROM (SELECT 1 FROM \"A\" WHERE \"Column1\" IS NOT NULL AND \"Column2\" IS NOT NULL) AS \"AliasAggregateQuery\"", c[EngineCodes.PostgreSql]);
+            Assert.Throws<ArgumentException>(() =>
+                new Query("A").SelectAggregate("aggregate", new[] { "Column1", "Column2" }, "Alias")
+            );
         }
 
         [Fact]

--- a/QueryBuilder.Tests/AggregateTests.cs
+++ b/QueryBuilder.Tests/AggregateTests.cs
@@ -1,11 +1,18 @@
 using SqlKata.Compilers;
 using SqlKata.Tests.Infrastructure;
+using System;
 using Xunit;
 
 namespace SqlKata.Tests
 {
     public class AggregateTests : TestSupport
     {
+        [Fact]
+        public void AggregateAsEmpty()
+        {
+            Assert.Throws<ArgumentException>(() => new Query("A").AggregateAs("aggregate", new string[] { }));
+        }
+
         [Fact]
         public void CountAs()
         {

--- a/QueryBuilder.Tests/AggregateTests.cs
+++ b/QueryBuilder.Tests/AggregateTests.cs
@@ -7,19 +7,6 @@ namespace SqlKata.Tests
     public class AggregateTests : TestSupport
     {
         [Fact]
-        public void AsCount()
-        {
-            var query = new Query("A").AsCount();
-
-            var c = Compile(query);
-
-            Assert.Equal("SELECT COUNT(*) AS [count] FROM [A]", c[EngineCodes.SqlServer]);
-            Assert.Equal("SELECT COUNT(*) AS `count` FROM `A`", c[EngineCodes.MySql]);
-            Assert.Equal("SELECT COUNT(*) AS \"count\" FROM \"A\"", c[EngineCodes.PostgreSql]);
-            Assert.Equal("SELECT COUNT(*) AS \"COUNT\" FROM \"A\"", c[EngineCodes.Firebird]);
-        }
-
-        [Fact]
         public void CountAs()
         {
             var query = new Query("A").CountAs();
@@ -63,13 +50,13 @@ namespace SqlKata.Tests
         {
             {
                 var columns = new string[] { };
-                var query = new Query("A").AsCount(columns);
+                var query = new Query("A").CountAs(columns);
                 Compile(query);
                 Assert.Equal(columns, new string[] { });
             }
             {
                 var columns = new[] { "ColumnA", "ColumnB" };
-                var query = new Query("A").AsCount(columns);
+                var query = new Query("A").CountAs(columns);
                 Compile(query);
                 Assert.Equal(columns, new[] { "ColumnA", "ColumnB" });
             }
@@ -78,7 +65,7 @@ namespace SqlKata.Tests
         [Fact]
         public void CountMultipleColumns()
         {
-            var query = new Query("A").AsCount(new[] { "ColumnA", "ColumnB" });
+            var query = new Query("A").CountAs(new[] { "ColumnA", "ColumnB" });
 
             var c = Compile(query);
 
@@ -98,7 +85,7 @@ namespace SqlKata.Tests
         [Fact]
         public void DistinctCount()
         {
-            var query = new Query("A").Distinct().AsCount();
+            var query = new Query("A").Distinct().CountAs();
 
             var c = Compile(query);
 
@@ -108,7 +95,7 @@ namespace SqlKata.Tests
         [Fact]
         public void DistinctCountMultipleColumns()
         {
-            var query = new Query("A").Distinct().AsCount(new[] { "ColumnA", "ColumnB" });
+            var query = new Query("A").Distinct().CountAs(new[] { "ColumnA", "ColumnB" });
 
             var c = Compile(query);
 

--- a/QueryBuilder.Tests/AggregateTests.cs
+++ b/QueryBuilder.Tests/AggregateTests.cs
@@ -14,6 +14,58 @@ namespace SqlKata.Tests
         }
 
         [Fact]
+        public void AggregateAs()
+        {
+            var query = new Query("A").AggregateAs("aggregate", new[] { "Column" });
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT AGGREGATE([Column]) AS [aggregate] FROM [A]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT AGGREGATE(`Column`) AS `aggregate` FROM `A`", c[EngineCodes.MySql]);
+            Assert.Equal("SELECT AGGREGATE(\"Column\") AS \"aggregate\" FROM \"A\"", c[EngineCodes.PostgreSql]);
+            Assert.Equal("SELECT AGGREGATE(\"COLUMN\") AS \"AGGREGATE\" FROM \"A\"", c[EngineCodes.Firebird]);
+        }
+
+        [Fact]
+        public void AggregateAsAlias()
+        {
+            var query = new Query("A").AggregateAs("aggregate", new[] { "Column" }, "Alias");
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT AGGREGATE([Column]) AS [Alias] FROM [A]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT AGGREGATE(`Column`) AS `Alias` FROM `A`", c[EngineCodes.MySql]);
+            Assert.Equal("SELECT AGGREGATE(\"Column\") AS \"Alias\" FROM \"A\"", c[EngineCodes.PostgreSql]);
+            Assert.Equal("SELECT AGGREGATE(\"COLUMN\") AS \"ALIAS\" FROM \"A\"", c[EngineCodes.Firebird]);
+        }
+
+        [Fact]
+        public void AggregateAsMultipleColumns()
+        {
+            var query = new Query("A").AggregateAs("aggregate", new[] { "Column1", "Column2" });
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT AGGREGATE(*) AS [aggregate] FROM (SELECT 1 FROM [A] WHERE [Column1] IS NOT NULL AND [Column2] IS NOT NULL) AS [AggregateQuery]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT AGGREGATE(*) AS `aggregate` FROM (SELECT 1 FROM `A` WHERE `Column1` IS NOT NULL AND `Column2` IS NOT NULL) AS `AggregateQuery`", c[EngineCodes.MySql]);
+            Assert.Equal("SELECT AGGREGATE(*) AS \"AGGREGATE\" FROM (SELECT 1 FROM \"A\" WHERE \"COLUMN1\" IS NOT NULL AND \"COLUMN2\" IS NOT NULL) AS \"AGGREGATEQUERY\"", c[EngineCodes.Firebird]);
+            Assert.Equal("SELECT AGGREGATE(*) AS \"aggregate\" FROM (SELECT 1 FROM \"A\" WHERE \"Column1\" IS NOT NULL AND \"Column2\" IS NOT NULL) AS \"AggregateQuery\"", c[EngineCodes.PostgreSql]);
+        }
+
+        [Fact]
+        public void AggregateAsMultipleColumnsAlias()
+        {
+            var query = new Query("A").AggregateAs("aggregate", new[] { "Column1", "Column2" }, "Alias");
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT AGGREGATE(*) AS [Alias] FROM (SELECT 1 FROM [A] WHERE [Column1] IS NOT NULL AND [Column2] IS NOT NULL) AS [AliasAggregateQuery]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT AGGREGATE(*) AS `Alias` FROM (SELECT 1 FROM `A` WHERE `Column1` IS NOT NULL AND `Column2` IS NOT NULL) AS `AliasAggregateQuery`", c[EngineCodes.MySql]);
+            Assert.Equal("SELECT AGGREGATE(*) AS \"ALIAS\" FROM (SELECT 1 FROM \"A\" WHERE \"COLUMN1\" IS NOT NULL AND \"COLUMN2\" IS NOT NULL) AS \"ALIASAGGREGATEQUERY\"", c[EngineCodes.Firebird]);
+            Assert.Equal("SELECT AGGREGATE(*) AS \"Alias\" FROM (SELECT 1 FROM \"A\" WHERE \"Column1\" IS NOT NULL AND \"Column2\" IS NOT NULL) AS \"AliasAggregateQuery\"", c[EngineCodes.PostgreSql]);
+        }
+
+        [Fact]
         public void CountAs()
         {
             var query = new Query("A").CountAs();
@@ -112,7 +164,7 @@ namespace SqlKata.Tests
         [Fact]
         public void Average()
         {
-            var query = new Query("A").AsAverage("TTL");
+            var query = new Query("A").AverageAs("TTL");
 
             var c = Compile(query);
 
@@ -120,9 +172,19 @@ namespace SqlKata.Tests
         }
 
         [Fact]
+        public void AverageAlias()
+        {
+            var query = new Query("A").AverageAs("TTL", "Alias");
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT AVG([TTL]) AS [Alias] FROM [A]", c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
         public void Sum()
         {
-            var query = new Query("A").AsSum("PacketsDropped");
+            var query = new Query("A").SumAs("PacketsDropped");
 
             var c = Compile(query);
 
@@ -130,9 +192,19 @@ namespace SqlKata.Tests
         }
 
         [Fact]
+        public void SumAlias()
+        {
+            var query = new Query("A").SumAs("PacketsDropped", "Alias");
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT SUM([PacketsDropped]) AS [Alias] FROM [A]", c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
         public void Max()
         {
-            var query = new Query("A").AsMax("LatencyMs");
+            var query = new Query("A").MaxAs("LatencyMs");
 
             var c = Compile(query);
 
@@ -140,13 +212,33 @@ namespace SqlKata.Tests
         }
 
         [Fact]
+        public void MaxAlias()
+        {
+            var query = new Query("A").MaxAs("LatencyMs", "Alias");
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT MAX([LatencyMs]) AS [Alias] FROM [A]", c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
         public void Min()
         {
-            var query = new Query("A").AsMin("LatencyMs");
+            var query = new Query("A").MinAs("LatencyMs");
 
             var c = Compile(query);
 
             Assert.Equal("SELECT MIN([LatencyMs]) AS [min] FROM [A]", c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
+        public void MinAlias()
+        {
+            var query = new Query("A").MinAs("LatencyMs", "Alias");
+
+            var c = Compile(query);
+
+            Assert.Equal("SELECT MIN([LatencyMs]) AS [Alias] FROM [A]", c[EngineCodes.SqlServer]);
         }
     }
 }

--- a/QueryBuilder.Tests/DefineTest.cs
+++ b/QueryBuilder.Tests/DefineTest.cs
@@ -29,7 +29,7 @@ namespace SqlKata.Tests
         {
 
             var subquery = new Query("Products")
-                .AverageAs("unitprice")
+                .SelectAverage("unitprice")
                 .Define("@UnitsInSt", 10)
                 .Where("UnitsInStock", ">", Variable("@UnitsInSt"));
 
@@ -252,7 +252,7 @@ namespace SqlKata.Tests
                .Where(q =>
                    q.Where("ShipRegion", "!=", Variable("@shipReg"))
                 //    .WhereRaw("1 = @one")
-                ).CountAs();
+                ).SelectCount();
 
             var c = Compile(query);
 

--- a/QueryBuilder.Tests/DefineTest.cs
+++ b/QueryBuilder.Tests/DefineTest.cs
@@ -252,7 +252,7 @@ namespace SqlKata.Tests
                .Where(q =>
                    q.Where("ShipRegion", "!=", Variable("@shipReg"))
                 //    .WhereRaw("1 = @one")
-                ).AsCount();
+                ).CountAs();
 
             var c = Compile(query);
 

--- a/QueryBuilder.Tests/DefineTest.cs
+++ b/QueryBuilder.Tests/DefineTest.cs
@@ -29,7 +29,7 @@ namespace SqlKata.Tests
         {
 
             var subquery = new Query("Products")
-                .AsAverage("unitprice")
+                .AverageAs("unitprice")
                 .Define("@UnitsInSt", 10)
                 .Where("UnitsInStock", ">", Variable("@UnitsInSt"));
 

--- a/QueryBuilder.Tests/SelectTests.cs
+++ b/QueryBuilder.Tests/SelectTests.cs
@@ -35,6 +35,31 @@ namespace SqlKata.Tests
             Assert.Equal("SELECT \"id\", \"name\" FROM \"users\"", c[EngineCodes.Oracle]);
         }
 
+        public void SelectAs()
+        {
+            var query = new Query().SelectAs(("Row", "Alias")).From("Table");
+
+            var c = Compile(query);
+            Assert.Equal("SELECT [Row] AS [Alias] FROM [Table]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT `Row` AS `Alias` FROM `Table`", c[EngineCodes.MySql]);
+            Assert.Equal("SELECT \"Row\" AS \"Alias\" FROM \"Table\"", c[EngineCodes.PostgreSql]);
+            Assert.Equal("SELECT \"ROW\" AS \"ALIAS\" FROM \"TABLE\"", c[EngineCodes.Firebird]);
+            Assert.Equal("SELECT \"Row\" \"Alias\" FROM \"Table\"", c[EngineCodes.Oracle]);
+        }
+
+        [Fact]
+        public void SelectAsMultipleColumns()
+        {
+            var query = new Query().SelectAs(("Row1", "Alias1"), ("Row2", "Alias2")).From("Table");
+
+            var c = Compile(query);
+            Assert.Equal("SELECT [Row1] AS [Alias1], [Row2] AS [Alias2] FROM [Table]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT `Row1` AS `Alias1`, `Row2` AS `Alias2` FROM `Table`", c[EngineCodes.MySql]);
+            Assert.Equal("SELECT \"Row1\" AS \"Alias1\", \"Row2\" AS \"Alias2\" FROM \"Table\"", c[EngineCodes.PostgreSql]);
+            Assert.Equal("SELECT \"ROW1\" AS \"ALIAS1\", \"ROW2\" AS \"ALIAS2\" FROM \"TABLE\"", c[EngineCodes.Firebird]);
+            Assert.Equal("SELECT \"Row1\" \"Alias1\", \"Row2\" \"Alias2\" FROM \"Table\"", c[EngineCodes.Oracle]);
+        }
+
         [Fact]
         public void BasicSelectWhereBindingIsEmptyOrNull()
         {
@@ -72,6 +97,21 @@ namespace SqlKata.Tests
 
             Assert.Equal("SELECT [users].[id], [users].[name], [users].[age] FROM [users]", c[EngineCodes.SqlServer]);
             Assert.Equal("SELECT `users`.`id`, `users`.`name`, `users`.`age` FROM `users`", c[EngineCodes.MySql]);
+        }
+
+        [Fact]
+        public void ExpandedSelectAs()
+        {
+            var q = new Query().From("users").SelectAs(("users.{id,name, age}", "Alias"));
+            var c = Compile(q);
+
+            // This result is weird (but valid syntax), and at least it works in
+            // a somewhat explainable way, as opposed to regular Select() when
+            // combining the expanded syntax and the 'as' SQLKata keyword support
+            // which simply silently stops working when the {...} expansion is
+            // applied.
+            Assert.Equal("SELECT [users].[id] AS [Alias], [users].[name] AS [Alias], [users].[age] AS [Alias] FROM [users]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT `users`.`id` AS `Alias`, `users`.`name` AS `Alias`, `users`.`age` AS `Alias` FROM `users`", c[EngineCodes.MySql]);
         }
 
         [Fact]

--- a/QueryBuilder.Tests/SelectTests.cs
+++ b/QueryBuilder.Tests/SelectTests.cs
@@ -205,7 +205,7 @@ namespace SqlKata.Tests
         [Fact]
         public void WhereSub()
         {
-            var subQuery = new Query("Table2").WhereColumns("Table2.Column", "=", "Table.MyCol").AsCount();
+            var subQuery = new Query("Table2").WhereColumns("Table2.Column", "=", "Table.MyCol").CountAs();
 
             var query = new Query("Table").WhereSub(subQuery, 1);
 
@@ -219,7 +219,7 @@ namespace SqlKata.Tests
         [Fact]
         public void OrWhereSub()
         {
-            var subQuery = new Query("Table2").WhereColumns("Table2.Column", "=", "Table.MyCol").AsCount();
+            var subQuery = new Query("Table2").WhereColumns("Table2.Column", "=", "Table.MyCol").CountAs();
 
             var query = new Query("Table").WhereNull("MyCol").OrWhereSub(subQuery, "<", 1);
 

--- a/QueryBuilder.Tests/SelectTests.cs
+++ b/QueryBuilder.Tests/SelectTests.cs
@@ -106,10 +106,9 @@ namespace SqlKata.Tests
             var c = Compile(q);
 
             // This result is weird (but valid syntax), and at least it works in
-            // a somewhat explainable way, as opposed to regular Select() when
-            // combining the expanded syntax and the 'as' SQLKata keyword support
-            // which simply silently stops working when the {...} expansion is
-            // applied.
+            // a somewhat explainable way. The regular 'as' keyword support in
+            // Select() does not work when combined with the {...}-expansion
+            // syntax (the alias will be lost).
             Assert.Equal("SELECT [users].[id] AS [Alias], [users].[name] AS [Alias], [users].[age] AS [Alias] FROM [users]", c[EngineCodes.SqlServer]);
             Assert.Equal("SELECT `users`.`id` AS `Alias`, `users`.`name` AS `Alias`, `users`.`age` AS `Alias` FROM `users`", c[EngineCodes.MySql]);
         }

--- a/QueryBuilder.Tests/SelectTests.cs
+++ b/QueryBuilder.Tests/SelectTests.cs
@@ -205,7 +205,7 @@ namespace SqlKata.Tests
         [Fact]
         public void WhereSub()
         {
-            var subQuery = new Query("Table2").WhereColumns("Table2.Column", "=", "Table.MyCol").CountAs();
+            var subQuery = new Query("Table2").WhereColumns("Table2.Column", "=", "Table.MyCol").SelectCount();
 
             var query = new Query("Table").WhereSub(subQuery, 1);
 
@@ -219,7 +219,7 @@ namespace SqlKata.Tests
         [Fact]
         public void OrWhereSub()
         {
-            var subQuery = new Query("Table2").WhereColumns("Table2.Column", "=", "Table.MyCol").CountAs();
+            var subQuery = new Query("Table2").WhereColumns("Table2.Column", "=", "Table.MyCol").SelectCount();
 
             var query = new Query("Table").WhereNull("MyCol").OrWhereSub(subQuery, "<", 1);
 

--- a/QueryBuilder/Clauses/AggregateClause.cs
+++ b/QueryBuilder/Clauses/AggregateClause.cs
@@ -17,6 +17,11 @@ namespace SqlKata
         public List<string> Columns { get; set; }
 
         /// <summary>
+        /// Gets or sets the alias of the result column.
+        /// </summary>
+        public string Alias { get; set; }
+
+        /// <summary>
         /// Gets or sets the type of aggregate function.
         /// </summary>
         /// <value>
@@ -32,6 +37,7 @@ namespace SqlKata
                 Engine = Engine,
                 Type = Type,
                 Columns = new List<string>(Columns),
+                Alias = Alias,
                 Component = Component,
             };
         }

--- a/QueryBuilder/Clauses/ColumnClause.cs
+++ b/QueryBuilder/Clauses/ColumnClause.cs
@@ -1,7 +1,10 @@
+using System.Diagnostics;
+
 namespace SqlKata
 {
     public abstract class AbstractColumn : AbstractClause
     {
+        public string Alias { get; set; }
     }
 
     /// <summary>
@@ -26,6 +29,7 @@ namespace SqlKata
                 Engine = Engine,
                 Name = Name,
                 Component = Component,
+                Alias = Alias,
             };
         }
     }
@@ -50,6 +54,7 @@ namespace SqlKata
                 Engine = Engine,
                 Query = Query.Clone(),
                 Component = Component,
+                Alias = Alias,
             };
         }
     }
@@ -68,6 +73,7 @@ namespace SqlKata
         /// <inheritdoc />
         public override AbstractClause Clone()
         {
+            Debug.Assert(string.IsNullOrEmpty(Alias), "Raw columns cannot have an alias");
             return new RawColumn
             {
                 Engine = Engine,

--- a/QueryBuilder/Clauses/ColumnClause.cs
+++ b/QueryBuilder/Clauses/ColumnClause.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace SqlKata
@@ -55,6 +56,23 @@ namespace SqlKata
                 Query = Query.Clone(),
                 Component = Component,
                 Alias = Alias,
+            };
+        }
+    }
+
+    public class AggregateColumn : AbstractColumn
+    {
+        public string Type { get; set; } // Min, Max, etc.
+        public string Column { get; set; } // Aggregate functions accept only a single 'value expression' (for now we implement only column name)
+        public override AbstractClause Clone()
+        {
+            return new AggregateColumn
+            {
+                Engine = Engine,
+                Component = Component,
+                Alias = Alias,
+                Type = Type,
+                Column = Column,
             };
         }
     }

--- a/QueryBuilder/Compilers/Compiler.cs
+++ b/QueryBuilder/Compilers/Compiler.cs
@@ -472,6 +472,12 @@ namespace SqlKata.Compilers
                 return "(" + subCtx.RawSql + $"){alias}";
             }
 
+            if (!string.IsNullOrWhiteSpace(column.Alias))
+            {
+                return $"{Wrap((column as Column).Name)} {ColumnAsKeyword}{Wrap(column.Alias)}";
+
+            }
+
             return Wrap((column as Column).Name);
 
         }

--- a/QueryBuilder/Compilers/Compiler.cs
+++ b/QueryBuilder/Compilers/Compiler.cs
@@ -475,6 +475,11 @@ namespace SqlKata.Compilers
                 return "(" + subCtx.RawSql + $"){alias}";
             }
 
+            if (column is AggregateColumn aggregate)
+            {
+                return $"{aggregate.Type.ToUpperInvariant()}({CompileColumn(ctx, new Column { Name = aggregate.Column })}) {ColumnAsKeyword}{WrapValue(aggregate.Alias ?? aggregate.Type)}";
+            }
+
             if (!string.IsNullOrWhiteSpace(column.Alias))
             {
                 return $"{Wrap((column as Column).Name)} {ColumnAsKeyword}{Wrap(column.Alias)}";

--- a/QueryBuilder/Compilers/Compiler.cs
+++ b/QueryBuilder/Compilers/Compiler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 
@@ -69,7 +70,7 @@ namespace SqlKata.Compilers
             {
                 query.ClearComponent("aggregate", EngineCode);
                 query.ClearComponent("select", EngineCode);
-                query.Select(clause.Columns.ToArray());
+                query.SelectAs(clause.Columns.Select(x => (x, null as string)).ToArray());
             }
             else
             {
@@ -82,12 +83,14 @@ namespace SqlKata.Compilers
             var outerClause = new AggregateClause()
             {
                 Columns = new List<string> { "*" },
-                Type = clause.Type
+                Type = clause.Type,
+                Alias = clause.Alias,
             };
 
             return new Query()
                 .AddComponent("aggregate", outerClause)
-                .From(query, $"{clause.Type}Query");
+                // Use alias + capitalized type + 'query' as alias
+                .From(query, $"{clause.Alias}{clause.Type.First().ToString().ToUpperInvariant()}{clause.Type.Substring(1)}Query");
         }
 
         protected virtual SqlResult CompileRaw(Query query)
@@ -534,9 +537,12 @@ namespace SqlKata.Compilers
                         sql = "DISTINCT " + sql;
                     }
 
-                    return "SELECT " + aggregate.Type.ToUpperInvariant() + "(" + sql + $") {ColumnAsKeyword}" + WrapValue(aggregate.Type);
+                    return $"SELECT {aggregate.Type.ToUpperInvariant()}({sql}) {ColumnAsKeyword}{WrapValue(aggregate.Alias ?? aggregate.Type)}";
                 }
 
+                // Counts of multiple columns are implemented by a sub-query
+                // which selects 1 from every non-null record. E.g.
+                // SELECT COUNT(*) FROM (SELECT 1 FROM [A] WHERE [ColumnA] IS NOT NULL AND [ColumnB] IS NOT NULL)
                 return "SELECT 1";
             }
 

--- a/QueryBuilder/Query.Aggregate.cs
+++ b/QueryBuilder/Query.Aggregate.cs
@@ -30,18 +30,6 @@ namespace SqlKata
             return this;
         }
 
-        public Query AsCount(string[] columns = null)
-        {
-            var cols = columns?.ToList() ?? new List<string> { };
-
-            if (!cols.Any())
-            {
-                cols.Add("*");
-            }
-
-            return AsAggregate("count", cols.ToArray());
-        }
-
         public Query CountAs(string column = null, string alias = null)
         {
             return CountAs(new[] { column ?? "*" }, alias);

--- a/QueryBuilder/Query.Aggregate.cs
+++ b/QueryBuilder/Query.Aggregate.cs
@@ -8,7 +8,7 @@ namespace SqlKata
         /**********************************************************************
          ** Generic aggregate                                                **
          **********************************************************************/
-        public Query AggregateAs(string type, IEnumerable<string> columns, string alias = null)
+        public Query SelectAggregate(string type, IEnumerable<string> columns, string alias = null)
         {
             if (columns.Count() == 0)
             {
@@ -32,55 +32,55 @@ namespace SqlKata
         /**********************************************************************
          ** Count                                                            **
          **********************************************************************/
-        public Query CountAs(string column = null, string alias = null)
+        public Query SelectCount(string column = null, string alias = null)
         {
-            return CountAs(column != null ? new[] { column } : new string[] { }, alias);
+            return SelectCount(column != null ? new[] { column } : new string[] { }, alias);
         }
 
-        public Query CountAs(IEnumerable<string> columns, string alias = null)
+        public Query SelectCount(IEnumerable<string> columns, string alias = null)
         {
-            return AggregateAs("count", columns.Count() == 0 ? new[] { "*" } : columns, alias);
+            return SelectAggregate("count", columns.Count() == 0 ? new[] { "*" } : columns, alias);
         }
 
 
         /**********************************************************************
          ** Average                                                          **
          **********************************************************************/
-        public Query AvgAs(string column, string alias = null)
+        public Query SelectAvg(string column, string alias = null)
         {
-            return AggregateAs("avg", new[] { column }, alias);
+            return SelectAggregate("avg", new[] { column }, alias);
         }
 
-        public Query AverageAs(string column, string alias = null)
+        public Query SelectAverage(string column, string alias = null)
         {
-            return AvgAs(column, alias);
+            return SelectAvg(column, alias);
         }
 
 
         /**********************************************************************
          ** Sum                                                              **
          **********************************************************************/
-        public Query SumAs(string column, string alias = null)
+        public Query SelectSum(string column, string alias = null)
         {
-            return AggregateAs("sum", new[] { column }, alias);
+            return SelectAggregate("sum", new[] { column }, alias);
         }
 
 
         /**********************************************************************
          ** Maximum                                                          **
          **********************************************************************/
-        public Query MaxAs(string column, string alias = null)
+        public Query SelectMax(string column, string alias = null)
         {
-            return AggregateAs("max", new[] { column }, alias);
+            return SelectAggregate("max", new[] { column }, alias);
         }
 
 
         /**********************************************************************
          ** Minimum                                                          **
          **********************************************************************/
-        public Query MinAs(string column, string alias = null)
+        public Query SelectMin(string column, string alias = null)
         {
-            return AggregateAs("min", new[] { column }, alias);
+            return SelectAggregate("min", new[] { column }, alias);
         }
     }
 }

--- a/QueryBuilder/Query.Aggregate.cs
+++ b/QueryBuilder/Query.Aggregate.cs
@@ -17,8 +17,12 @@ namespace SqlKata
 
             Method = "aggregate";
 
-            this.ClearComponent("aggregate")
-            .AddComponent("aggregate", new AggregateClause
+            if (this.HasComponent("aggregate"))
+            {
+                throw new System.InvalidOperationException("Cannot add more than one aggregate");
+            }
+
+            this.AddComponent("aggregate", new AggregateClause
             {
                 Type = type,
                 Columns = columns.ToList(),

--- a/QueryBuilder/Query.Aggregate.cs
+++ b/QueryBuilder/Query.Aggregate.cs
@@ -15,6 +15,15 @@ namespace SqlKata
                 throw new System.ArgumentException("Cannot aggregate without columns");
             }
 
+            // According to ISO/IEC 9075:2016 all aggregates take only a single
+            // value expression argument (i.e. one column). However, for the
+            // special case of count(...), SqlKata implements a transform to
+            // a sub query.
+            if (columns.Count() > 1 && type != "count")
+            {
+                throw new System.ArgumentException("Cannot aggregate more than one column at once");
+            }
+
             Method = "aggregate";
 
             if (this.HasComponent("aggregate"))

--- a/QueryBuilder/Query.Aggregate.cs
+++ b/QueryBuilder/Query.Aggregate.cs
@@ -14,8 +14,12 @@ namespace SqlKata
             );
         }
 
-        public Query AggregateAs(string type, IEnumerable<string> columns, string alias)
+        public Query AggregateAs(string type, IEnumerable<string> columns, string alias = null)
         {
+            if (columns.Count() == 0)
+            {
+                throw new System.ArgumentException("Cannot aggregate without columns");
+            }
 
             Method = "aggregate";
 
@@ -32,12 +36,12 @@ namespace SqlKata
 
         public Query CountAs(string column = null, string alias = null)
         {
-            return CountAs(new[] { column ?? "*" }, alias);
+            return CountAs(column != null ? new[] { column } : new string[] { }, alias);
         }
 
         public Query CountAs(IEnumerable<string> columns, string alias = null)
         {
-            return AggregateAs("count", columns, alias);
+            return AggregateAs("count", columns.Count() == 0 ? new[] { "*" } : columns, alias);
         }
 
         public Query AsAvg(string column)

--- a/QueryBuilder/Query.Aggregate.cs
+++ b/QueryBuilder/Query.Aggregate.cs
@@ -7,6 +7,15 @@ namespace SqlKata
     {
         public Query AsAggregate(string type, string[] columns = null)
         {
+            return AggregateAs(
+                type,
+                columns ?? new string[] { },
+                null // old interface always uses 'type' as alias name
+            );
+        }
+
+        public Query AggregateAs(string type, IEnumerable<string> columns, string alias)
+        {
 
             Method = "aggregate";
 
@@ -14,7 +23,8 @@ namespace SqlKata
             .AddComponent("aggregate", new AggregateClause
             {
                 Type = type,
-                Columns = columns?.ToList() ?? new List<string>(),
+                Columns = columns.ToList(),
+                Alias = alias
             });
 
             return this;
@@ -30,6 +40,16 @@ namespace SqlKata
             }
 
             return AsAggregate("count", cols.ToArray());
+        }
+
+        public Query CountAs(string column = null, string alias = null)
+        {
+            return CountAs(new[] { column ?? "*" }, alias);
+        }
+
+        public Query CountAs(IEnumerable<string> columns, string alias = null)
+        {
+            return AggregateAs("count", columns, alias);
         }
 
         public Query AsAvg(string column)

--- a/QueryBuilder/Query.Aggregate.cs
+++ b/QueryBuilder/Query.Aggregate.cs
@@ -5,15 +5,9 @@ namespace SqlKata
 {
     public partial class Query
     {
-        public Query AsAggregate(string type, string[] columns = null)
-        {
-            return AggregateAs(
-                type,
-                columns ?? new string[] { },
-                null // old interface always uses 'type' as alias name
-            );
-        }
-
+        /**********************************************************************
+         ** Generic aggregate                                                **
+         **********************************************************************/
         public Query AggregateAs(string type, IEnumerable<string> columns, string alias = null)
         {
             if (columns.Count() == 0)
@@ -34,6 +28,10 @@ namespace SqlKata
             return this;
         }
 
+
+        /**********************************************************************
+         ** Count                                                            **
+         **********************************************************************/
         public Query CountAs(string column = null, string alias = null)
         {
             return CountAs(column != null ? new[] { column } : new string[] { }, alias);
@@ -44,28 +42,45 @@ namespace SqlKata
             return AggregateAs("count", columns.Count() == 0 ? new[] { "*" } : columns, alias);
         }
 
-        public Query AsAvg(string column)
+
+        /**********************************************************************
+         ** Average                                                          **
+         **********************************************************************/
+        public Query AvgAs(string column, string alias = null)
         {
-            return AsAggregate("avg", new string[] { column });
-        }
-        public Query AsAverage(string column)
-        {
-            return AsAvg(column);
+            return AggregateAs("avg", new[] { column }, alias);
         }
 
-        public Query AsSum(string column)
+        public Query AverageAs(string column, string alias = null)
         {
-            return AsAggregate("sum", new[] { column });
+            return AvgAs(column, alias);
         }
 
-        public Query AsMax(string column)
+
+        /**********************************************************************
+         ** Sum                                                              **
+         **********************************************************************/
+        public Query SumAs(string column, string alias = null)
         {
-            return AsAggregate("max", new[] { column });
+            return AggregateAs("sum", new[] { column }, alias);
         }
 
-        public Query AsMin(string column)
+
+        /**********************************************************************
+         ** Maximum                                                          **
+         **********************************************************************/
+        public Query MaxAs(string column, string alias = null)
         {
-            return AsAggregate("min", new[] { column });
+            return AggregateAs("max", new[] { column }, alias);
+        }
+
+
+        /**********************************************************************
+         ** Minimum                                                          **
+         **********************************************************************/
+        public Query MinAs(string column, string alias = null)
+        {
+            return AggregateAs("min", new[] { column }, alias);
         }
     }
 }

--- a/QueryBuilder/Query.Aggregate.cs
+++ b/QueryBuilder/Query.Aggregate.cs
@@ -24,19 +24,30 @@ namespace SqlKata
                 throw new System.ArgumentException("Cannot aggregate more than one column at once");
             }
 
-            Method = "aggregate";
-
-            if (this.HasComponent("aggregate"))
+            if (type != "count" || (columns.Count() == 1 && !this.IsDistinct))
             {
-                throw new System.InvalidOperationException("Cannot add more than one aggregate");
+                Method = "select";
+                this.AddComponent("select", new AggregateColumn
+                {
+                    Alias = alias,
+                    Type = type,
+                    Column = columns.First(),
+                });
             }
-
-            this.AddComponent("aggregate", new AggregateClause
+            else
             {
-                Type = type,
-                Columns = columns.ToList(),
-                Alias = alias
-            });
+                if (this.HasComponent("aggregate"))
+                {
+                    throw new System.InvalidOperationException("Cannot add more than one top-level aggregate clause");
+                }
+                Method = "aggregate";
+                this.AddComponent("aggregate", new AggregateClause
+                {
+                    Alias = alias,
+                    Type = type,
+                    Columns = columns.ToList(),
+                });
+            }
 
             return this;
         }

--- a/QueryBuilder/Query.Select.cs
+++ b/QueryBuilder/Query.Select.cs
@@ -6,27 +6,35 @@ namespace SqlKata
 {
     public partial class Query
     {
+        public Query Select(params string[] columns) =>
+            Select(columns.AsEnumerable());
 
-        public Query Select(params string[] columns)
-        {
-            return Select(columns.AsEnumerable());
-        }
+        public Query Select(IEnumerable<string> columns) =>
+            SelectAs(
+                columns
+                .Select(x => (x, null as string))
+                .ToArray()
+            );
 
-        public Query Select(IEnumerable<string> columns)
+        /// <summary>
+        /// Select columns with an alias
+        /// </summary>
+        /// <returns></returns>
+        public Query SelectAs(params (string, string)[] columns)
         {
             Method = "select";
 
             columns = columns
-                .Select(x => Helper.ExpandExpression(x))
+                .Select(x => Helper.ExpandExpression(x.Item1).Select(y => (y, x.Item2)))
                 .SelectMany(x => x)
                 .ToArray();
-
 
             foreach (var column in columns)
             {
                 AddComponent("select", new Column
                 {
-                    Name = column
+                    Name = column.Item1,
+                    Alias = column.Item2
                 });
             }
 

--- a/SqlKata.Execution/Query.Extensions.cs
+++ b/SqlKata.Execution/Query.Extensions.cs
@@ -279,13 +279,13 @@ namespace SqlKata.Execution
         {
             var db = CreateQueryFactory(query);
 
-            return db.ExecuteScalar<T>(query.AsAggregate(aggregateOperation, columns), transaction, timeout);
+            return db.ExecuteScalar<T>(query.AggregateAs(aggregateOperation, columns), transaction, timeout);
         }
 
         public static async Task<T> AggregateAsync<T>(this Query query, string aggregateOperation, string[] columns, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
             var db = CreateQueryFactory(query);
-            return await db.ExecuteScalarAsync<T>(query.AsAggregate(aggregateOperation, columns), transaction, timeout, cancellationToken);
+            return await db.ExecuteScalarAsync<T>(query.AggregateAs(aggregateOperation, columns), transaction, timeout, cancellationToken);
         }
 
         public static T Count<T>(this Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null)

--- a/SqlKata.Execution/Query.Extensions.cs
+++ b/SqlKata.Execution/Query.Extensions.cs
@@ -275,71 +275,71 @@ namespace SqlKata.Execution
             return await CreateQueryFactory(query).ExecuteAsync(query.AsDelete(), transaction, timeout, cancellationToken);
         }
 
-        public static T Aggregate<T>(this Query query, string aggregateOperation, string[] columns, IDbTransaction transaction = null, int? timeout = null)
+        public static T SelectAggregate<T>(this Query query, string aggregateOperation, string[] columns, IDbTransaction transaction = null, int? timeout = null)
         {
             var db = CreateQueryFactory(query);
 
-            return db.ExecuteScalar<T>(query.AggregateAs(aggregateOperation, columns), transaction, timeout);
+            return db.ExecuteScalar<T>(query.SelectAggregate(aggregateOperation, columns), transaction, timeout);
         }
 
-        public static async Task<T> AggregateAsync<T>(this Query query, string aggregateOperation, string[] columns, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
+        public static async Task<T> SelectAggregateAsync<T>(this Query query, string aggregateOperation, string[] columns, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
             var db = CreateQueryFactory(query);
-            return await db.ExecuteScalarAsync<T>(query.AggregateAs(aggregateOperation, columns), transaction, timeout, cancellationToken);
+            return await db.ExecuteScalarAsync<T>(query.SelectAggregate(aggregateOperation, columns), transaction, timeout, cancellationToken);
         }
 
-        public static T Count<T>(this Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null)
-        {
-            var db = CreateQueryFactory(query);
-
-            return db.ExecuteScalar<T>(query.CountAs(columns), transaction, timeout);
-        }
-
-        public static async Task<T> CountAsync<T>(this Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
+        public static T SelectCount<T>(this Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null)
         {
             var db = CreateQueryFactory(query);
 
-            return await db.ExecuteScalarAsync<T>(query.CountAs(columns), transaction, timeout, cancellationToken);
+            return db.ExecuteScalar<T>(query.SelectCount(columns), transaction, timeout);
         }
 
-        public static T Average<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<T> SelectCountAsync<T>(this Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return query.Aggregate<T>("avg", new[] { column }, transaction, timeout);
+            var db = CreateQueryFactory(query);
+
+            return await db.ExecuteScalarAsync<T>(query.SelectCount(columns), transaction, timeout, cancellationToken);
         }
 
-        public static async Task<T> AverageAsync<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
+        public static T SelectAverage<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
         {
-            return await query.AggregateAsync<T>("avg", new[] { column }, transaction, timeout, cancellationToken);
+            return query.SelectAggregate<T>("avg", new[] { column }, transaction, timeout);
         }
 
-        public static T Sum<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<T> SelectAverageAsync<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return query.Aggregate<T>("sum", new[] { column }, transaction, timeout);
+            return await query.SelectAggregateAsync<T>("avg", new[] { column }, transaction, timeout, cancellationToken);
         }
 
-        public static async Task<T> SumAsync<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
+        public static T SelectSum<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
         {
-            return await query.AggregateAsync<T>("sum", new[] { column }, transaction, timeout, cancellationToken);
+            return query.SelectAggregate<T>("sum", new[] { column }, transaction, timeout);
         }
 
-        public static T Min<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<T> SelectSumAsync<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return query.Aggregate<T>("min", new[] { column }, transaction, timeout);
+            return await query.SelectAggregateAsync<T>("sum", new[] { column }, transaction, timeout, cancellationToken);
         }
 
-        public static async Task<T> MinAsync<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
+        public static T SelectMin<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
         {
-            return await query.AggregateAsync<T>("min", new[] { column }, transaction, timeout, cancellationToken);
+            return query.SelectAggregate<T>("min", new[] { column }, transaction, timeout);
         }
 
-        public static T Max<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
+        public static async Task<T> SelectMinAsync<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return query.Aggregate<T>("max", new[] { column }, transaction, timeout);
+            return await query.SelectAggregateAsync<T>("min", new[] { column }, transaction, timeout, cancellationToken);
         }
 
-        public static async Task<T> MaxAsync<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
+        public static T SelectMax<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)
         {
-            return await query.AggregateAsync<T>("max", new[] { column }, transaction, timeout, cancellationToken);
+            return query.SelectAggregate<T>("max", new[] { column }, transaction, timeout);
+        }
+
+        public static async Task<T> SelectMaxAsync<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
+        {
+            return await query.SelectAggregateAsync<T>("max", new[] { column }, transaction, timeout, cancellationToken);
         }
 
         internal static XQuery CastToXQuery(Query query, string method = null)

--- a/SqlKata.Execution/Query.Extensions.cs
+++ b/SqlKata.Execution/Query.Extensions.cs
@@ -292,14 +292,14 @@ namespace SqlKata.Execution
         {
             var db = CreateQueryFactory(query);
 
-            return db.ExecuteScalar<T>(query.AsCount(columns), transaction, timeout);
+            return db.ExecuteScalar<T>(query.CountAs(columns), transaction, timeout);
         }
 
         public static async Task<T> CountAsync<T>(this Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
             var db = CreateQueryFactory(query);
 
-            return await db.ExecuteScalarAsync<T>(query.AsCount(columns), transaction, timeout, cancellationToken);
+            return await db.ExecuteScalarAsync<T>(query.CountAs(columns), transaction, timeout, cancellationToken);
         }
 
         public static T Average<T>(this Query query, string column, IDbTransaction transaction = null, int? timeout = null)

--- a/SqlKata.Execution/QueryFactory.cs
+++ b/SqlKata.Execution/QueryFactory.cs
@@ -372,7 +372,7 @@ namespace SqlKata.Execution
             return rows.Any();
         }
 
-        public T Aggregate<T>(
+        public T SelectAggregate<T>(
             Query query,
             string aggregateOperation,
             string[] columns = null,
@@ -380,10 +380,10 @@ namespace SqlKata.Execution
             int? timeout = null
         )
         {
-            return this.ExecuteScalar<T>(query.AggregateAs(aggregateOperation, columns), transaction, timeout ?? this.QueryTimeout);
+            return this.ExecuteScalar<T>(query.SelectAggregate(aggregateOperation, columns), transaction, timeout ?? this.QueryTimeout);
         }
 
-        public async Task<T> AggregateAsync<T>(
+        public async Task<T> SelectAggregateAsync<T>(
             Query query,
             string aggregateOperation,
             string[] columns = null,
@@ -393,65 +393,65 @@ namespace SqlKata.Execution
         )
         {
             return await this.ExecuteScalarAsync<T>(
-                query.AggregateAs(aggregateOperation, columns),
+                query.SelectAggregate(aggregateOperation, columns),
                 transaction,
                 timeout,
                 cancellationToken
             );
         }
 
-        public T Count<T>(Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null)
+        public T SelectCount<T>(Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null)
         {
             return this.ExecuteScalar<T>(
-                query.CountAs(columns),
+                query.SelectCount(columns),
                 transaction,
                 timeout
             );
         }
 
-        public async Task<T> CountAsync<T>(Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
+        public async Task<T> SelectCountAsync<T>(Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await this.ExecuteScalarAsync<T>(query.CountAs(columns), transaction, timeout, cancellationToken);
+            return await this.ExecuteScalarAsync<T>(query.SelectCount(columns), transaction, timeout, cancellationToken);
         }
 
-        public T Average<T>(Query query, string column, IDbTransaction transaction = null, int? timeout = null)
+        public T SelectAverage<T>(Query query, string column, IDbTransaction transaction = null, int? timeout = null)
         {
-            return this.Aggregate<T>(query, "avg", new[] { column });
+            return this.SelectAggregate<T>(query, "avg", new[] { column });
         }
 
-        public async Task<T> AverageAsync<T>(Query query, string column, CancellationToken cancellationToken = default)
+        public async Task<T> SelectAverageAsync<T>(Query query, string column, CancellationToken cancellationToken = default)
         {
-            return await this.AggregateAsync<T>(query, "avg", new[] { column }, cancellationToken: cancellationToken);
+            return await this.SelectAggregateAsync<T>(query, "avg", new[] { column }, cancellationToken: cancellationToken);
         }
 
-        public T Sum<T>(Query query, string column)
+        public T SelectSum<T>(Query query, string column)
         {
-            return this.Aggregate<T>(query, "sum", new[] { column });
+            return this.SelectAggregate<T>(query, "sum", new[] { column });
         }
 
-        public async Task<T> SumAsync<T>(Query query, string column, CancellationToken cancellationToken = default)
+        public async Task<T> SelectSumAsync<T>(Query query, string column, CancellationToken cancellationToken = default)
         {
-            return await this.AggregateAsync<T>(query, "sum", new[] { column }, cancellationToken: cancellationToken);
+            return await this.SelectAggregateAsync<T>(query, "sum", new[] { column }, cancellationToken: cancellationToken);
         }
 
-        public T Min<T>(Query query, string column)
+        public T SelectMin<T>(Query query, string column)
         {
-            return this.Aggregate<T>(query, "min", new[] { column });
+            return this.SelectAggregate<T>(query, "min", new[] { column });
         }
 
-        public async Task<T> MinAsync<T>(Query query, string column, CancellationToken cancellationToken = default)
+        public async Task<T> SelectMinAsync<T>(Query query, string column, CancellationToken cancellationToken = default)
         {
-            return await this.AggregateAsync<T>(query, "min", new[] { column }, cancellationToken: cancellationToken);
+            return await this.SelectAggregateAsync<T>(query, "min", new[] { column }, cancellationToken: cancellationToken);
         }
 
-        public T Max<T>(Query query, string column)
+        public T SelectMax<T>(Query query, string column)
         {
-            return this.Aggregate<T>(query, "max", new[] { column });
+            return this.SelectAggregate<T>(query, "max", new[] { column });
         }
 
-        public async Task<T> MaxAsync<T>(Query query, string column, CancellationToken cancellationToken = default)
+        public async Task<T> SelectMaxAsync<T>(Query query, string column, CancellationToken cancellationToken = default)
         {
-            return await this.AggregateAsync<T>(query, "max", new[] { column }, cancellationToken: cancellationToken);
+            return await this.SelectAggregateAsync<T>(query, "max", new[] { column }, cancellationToken: cancellationToken);
         }
 
         public PaginationResult<T> Paginate<T>(Query query, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null)
@@ -466,7 +466,7 @@ namespace SqlKata.Execution
                 throw new ArgumentException("PerPage param should be greater than or equal to 1", nameof(perPage));
             }
 
-            var count = Count<long>(query.Clone(), null, transaction, timeout);
+            var count = SelectCount<long>(query.Clone(), null, transaction, timeout);
 
             IEnumerable<T> list;
 
@@ -501,7 +501,7 @@ namespace SqlKata.Execution
                 throw new ArgumentException("PerPage param should be greater than or equal to 1", nameof(perPage));
             }
 
-            var count = await CountAsync<long>(query.Clone(), null, transaction, timeout, cancellationToken);
+            var count = await SelectCountAsync<long>(query.Clone(), null, transaction, timeout, cancellationToken);
 
             IEnumerable<T> list;
 

--- a/SqlKata.Execution/QueryFactory.cs
+++ b/SqlKata.Execution/QueryFactory.cs
@@ -380,7 +380,7 @@ namespace SqlKata.Execution
             int? timeout = null
         )
         {
-            return this.ExecuteScalar<T>(query.AsAggregate(aggregateOperation, columns), transaction, timeout ?? this.QueryTimeout);
+            return this.ExecuteScalar<T>(query.AggregateAs(aggregateOperation, columns), transaction, timeout ?? this.QueryTimeout);
         }
 
         public async Task<T> AggregateAsync<T>(
@@ -393,7 +393,7 @@ namespace SqlKata.Execution
         )
         {
             return await this.ExecuteScalarAsync<T>(
-                query.AsAggregate(aggregateOperation, columns),
+                query.AggregateAs(aggregateOperation, columns),
                 transaction,
                 timeout,
                 cancellationToken

--- a/SqlKata.Execution/QueryFactory.cs
+++ b/SqlKata.Execution/QueryFactory.cs
@@ -285,7 +285,7 @@ namespace SqlKata.Execution
         public async Task<SqlMapper.GridReader> GetMultipleAsync<T>(
             Query[] queries,
             IDbTransaction transaction = null,
-            int? timeout = null, 
+            int? timeout = null,
             CancellationToken cancellationToken = default)
         {
             var compiled = this.Compiler.Compile(queries);
@@ -324,7 +324,7 @@ namespace SqlKata.Execution
         public async Task<IEnumerable<IEnumerable<T>>> GetAsync<T>(
             Query[] queries,
             IDbTransaction transaction = null,
-            int? timeout = null, 
+            int? timeout = null,
             CancellationToken cancellationToken = default
         )
         {
@@ -388,7 +388,7 @@ namespace SqlKata.Execution
             string aggregateOperation,
             string[] columns = null,
             IDbTransaction transaction = null,
-            int? timeout = null, 
+            int? timeout = null,
             CancellationToken cancellationToken = default
         )
         {
@@ -403,7 +403,7 @@ namespace SqlKata.Execution
         public T Count<T>(Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null)
         {
             return this.ExecuteScalar<T>(
-                query.AsCount(columns),
+                query.CountAs(columns),
                 transaction,
                 timeout
             );
@@ -411,7 +411,7 @@ namespace SqlKata.Execution
 
         public async Task<T> CountAsync<T>(Query query, string[] columns = null, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await this.ExecuteScalarAsync<T>(query.AsCount(columns), transaction, timeout, cancellationToken);
+            return await this.ExecuteScalarAsync<T>(query.CountAs(columns), transaction, timeout, cancellationToken);
         }
 
         public T Average<T>(Query query, string column, IDbTransaction transaction = null, int? timeout = null)
@@ -553,7 +553,7 @@ namespace SqlKata.Execution
             int chunkSize,
             Func<IEnumerable<T>, int, bool> func,
             IDbTransaction transaction = null,
-            int? timeout = null, 
+            int? timeout = null,
             CancellationToken cancellationToken = default
         )
         {
@@ -592,7 +592,7 @@ namespace SqlKata.Execution
             int chunkSize,
             Action<IEnumerable<T>, int> action,
             IDbTransaction transaction = null,
-            int? timeout = null, 
+            int? timeout = null,
             CancellationToken cancellationToken = default
         )
         {


### PR DESCRIPTION
This enables the writing of queries like `SELECT MIN(COLUMN), MAX(COLUMN), SUM(COLUMN) FROM TABLE`. The existing behaviour for handling multiple `COUNT()` columns is preserved as a special case.

Following from #499, this renames the `AsCount()` to `SelectCount()`, which as pointed out in does something different. If `AsCount()` should be kept as-is, what would be a good way (name) to make the distinction between what AsCount() does vs. selecting aggregates of columns?