### PR TITLE
Change License Tag in the *.csproj file

### DIFF
--- a/QueryBuilder/QueryBuilder.csproj
+++ b/QueryBuilder/QueryBuilder.csproj
@@ -14,7 +14,7 @@
     <PackageTags>sql;query-builder;dynamic-query</PackageTags>
     <PackageReleaseNotes>https://github.com/sqlkata/querybuilder</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/sqlkata/querybuilder</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/sqlkata/querybuilder/licence</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/sqlkata/querybuilder</RepositoryUrl>


### PR DESCRIPTION
… from PackageLicenseUrl to PackageLicenseExpression to conform with current standard.
See https://docs.microsoft.com/en-us/nuget/consume-packages/finding-and-choosing-packages#license-url-deprecation
and https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#packing-a-license-expression-or-a-license-file.

This makes the license type machine readable and thus shows up nicely on NuGet.org or other tools, like WhiteSource.