### PR TITLE
Include/IncludeMany on nullable FK no longer throws exception.

### DIFF
--- a/SqlKata.Execution/QueryFactory.cs
+++ b/SqlKata.Execution/QueryFactory.cs
@@ -749,8 +749,8 @@ namespace SqlKata.Execution
 
                 foreach (var item in dynamicResult)
                 {
-                    var foreignValue = item[include.ForeignKey].ToString();
-                    item[include.Name] = related.ContainsKey(foreignValue) ? related[foreignValue] : null;
+                    var foreignValue = item[include.ForeignKey]?.ToString();
+                    item[include.Name] = foreignValue != null && related.ContainsKey(foreignValue) ? related[foreignValue] : null;
                 }
             }
 
@@ -843,8 +843,8 @@ namespace SqlKata.Execution
 
                 foreach (var item in dynamicResult)
                 {
-                    var foreignValue = item[include.ForeignKey].ToString();
-                    item[include.Name] = related.ContainsKey(foreignValue) ? related[foreignValue] : null;
+                    var foreignValue = item[include.ForeignKey]?.ToString();
+                    item[include.Name] = foreignValue != null && related.ContainsKey(foreignValue) ? related[foreignValue] : null;
                 }
             }
 


### PR DESCRIPTION
When you use .Include on a nullable FK, an exception is thrown during the dynamicResult cast. Adding a guard here now allows mapping to continue as expected.