### PR TITLE
Option to convert object names to uppercase for OracleCompiler

### DIFF
--- a/QueryBuilder/Compilers/OracleCompiler.cs
+++ b/QueryBuilder/Compilers/OracleCompiler.cs
@@ -16,6 +16,7 @@ namespace SqlKata.Compilers
 
         public override string EngineCode { get; } = EngineCodes.Oracle;
         public bool UseLegacyPagination { get; set; } = false;
+        public bool UseUppercaseColumnName { get; set; } = false;
         protected override string SingleRowDummyTableName => "DUAL";
 
         protected override SqlResult CompileSelectQuery(Query query)
@@ -151,6 +152,13 @@ namespace SqlKata.Compilers
 
             return sql;
 
+        }
+
+        public override string Wrap(string value)
+        {
+            return UseUppercaseColumnName
+                ? base.Wrap(value.ToUpperInvariant())
+                : base.Wrap(value);
         }
     }
 }


### PR DESCRIPTION
Basically all Oracle databases I have seen automatically convert object names to uppercase, which makes us have to write ugly c# code like 
```csharp
public class Foo
{
    public string BAR{ get; set;}
}
```
or 
```csharp
public class Foo
{
    [Column("BAR")]
    public string Bar{ get; set;}
}
```
I think this option is necessary.