### PR TITLE
Performance on insert many

### DIFF
--- a/QueryBuilder.Tests/InsertTests.cs
+++ b/QueryBuilder.Tests/InsertTests.cs
@@ -100,6 +100,30 @@ namespace SqlKata.Tests
         }
 
         [Fact]
+        public void InsertMultiRecordsByDictionary()
+        {
+            var data = new List<Dictionary<string, object>>
+            {
+                new() { { "name", "Chiron" }, { "brand", "Bugatti" }, { "year", null } },
+                new() { { "name", "Huayra" }, { "brand", "Pagani" }, { "year", 2012 } },
+                new() { { "name", "Reventon roadster" }, { "brand", "Lamborghini" }, { "year", 2009 } }
+            };
+
+            var query = new Query("expensive_cars")
+                .AsInsert(data);
+
+            var c = Compile(query);
+
+            Assert.Equal(
+                "INSERT INTO [expensive_cars] ([name], [brand], [year]) VALUES ('Chiron', 'Bugatti', NULL), ('Huayra', 'Pagani', 2012), ('Reventon roadster', 'Lamborghini', 2009)",
+                c[EngineCodes.SqlServer]);
+
+            Assert.Equal(
+                "INSERT INTO \"EXPENSIVE_CARS\" (\"NAME\", \"BRAND\", \"YEAR\") SELECT 'Chiron', 'Bugatti', NULL FROM RDB$DATABASE UNION ALL SELECT 'Huayra', 'Pagani', 2012 FROM RDB$DATABASE UNION ALL SELECT 'Reventon roadster', 'Lamborghini', 2009 FROM RDB$DATABASE",
+                c[EngineCodes.Firebird]);
+        }
+
+        [Fact]
         public void InsertWithNullValues()
         {
             var query = new Query("Books")

--- a/QueryBuilder/Clauses/InsertClause.cs
+++ b/QueryBuilder/Clauses/InsertClause.cs
@@ -9,8 +9,7 @@ namespace SqlKata
 
     public class InsertClause : AbstractInsertClause
     {
-        public List<string> Columns { get; set; }
-        public List<object> Values { get; set; }
+        public Dictionary<string, object> Data { get; set; }
         public bool ReturnId { get; set; } = false;
 
         public override AbstractClause Clone()
@@ -19,8 +18,7 @@ namespace SqlKata
             {
                 Engine = Engine,
                 Component = Component,
-                Columns = Columns,
-                Values = Values,
+                Data = Data,
                 ReturnId = ReturnId,
             };
         }

--- a/QueryBuilder/Compilers/Compiler.Conditions.cs
+++ b/QueryBuilder/Compilers/Compiler.Conditions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 
 namespace SqlKata.Compilers
 {
@@ -43,7 +44,7 @@ namespace SqlKata.Compilers
 
         protected virtual string CompileConditions(SqlResult ctx, List<AbstractCondition> conditions)
         {
-            var result = new List<string>();
+            var result = new StringBuilder();
 
             for (var i = 0; i < conditions.Count; i++)
             {
@@ -56,10 +57,10 @@ namespace SqlKata.Compilers
 
                 var boolOperator = i == 0 ? "" : (conditions[i].IsOr ? "OR " : "AND ");
 
-                result.Add(boolOperator + compiled);
+                result.Append(boolOperator + compiled + " ");
             }
 
-            return string.Join(" ", result);
+            return result.ToString().Trim();
         }
 
         protected virtual string CompileRawCondition(SqlResult ctx, RawCondition x)

--- a/QueryBuilder/Extensions/CollectionExtensions.cs
+++ b/QueryBuilder/Extensions/CollectionExtensions.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SqlKata.Extensions
+{
+    public static class CollectionExtensions
+    {
+        public static Dictionary<string, object> MergeKeysAndValues(this List<string> keys, List<object> values)
+        {
+            var data = new Dictionary<string, object>();
+
+            for (var i = 0; i < keys.Count; i++)
+            {
+                data.Add(keys[i], values[i]);
+            }
+
+            return data;
+        }
+
+        public static Dictionary<string, object> CreateDictionary(this IEnumerable<KeyValuePair<string, object>> values)
+        {
+            if (values is Dictionary<string, object> dictionary)
+            {
+                return dictionary;
+            }
+
+            return values.ToDictionary(x => x.Key, x => x.Value);
+        }
+    }
+}

--- a/QueryBuilder/Helper.cs
+++ b/QueryBuilder/Helper.cs
@@ -96,14 +96,16 @@ namespace SqlKata
 
         public static string JoinArray(string glue, IEnumerable array)
         {
-            var result = new List<string>();
+            var result = new StringBuilder();
 
             foreach (var item in array)
             {
-                result.Add(item.ToString());
+                result.Append(item + glue);
             }
 
-            return string.Join(glue, result);
+            result.Length -= glue.Length;
+
+            return result.ToString().Trim();
         }
 
         public static string ExpandParameters(string sql, string placeholder, object[] bindings)

--- a/QueryBuilder/Query.Update.cs
+++ b/QueryBuilder/Query.Update.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using SqlKata.Extensions;
 
 namespace SqlKata
 {
@@ -16,12 +17,15 @@ namespace SqlKata
 
         public Query AsUpdate(IEnumerable<string> columns, IEnumerable<object> values)
         {
-            if ((columns?.Any() ?? false) == false || (values?.Any() ?? false) == false)
+            var columnsList = columns?.ToList();
+            var valuesList = values?.ToList();
+
+            if ((columnsList?.Count ?? 0) == 0 || (valuesList?.Count ?? 0) == 0)
             {
                 throw new InvalidOperationException($"{columns} and {values} cannot be null or empty");
             }
 
-            if (columns.Count() != values.Count())
+            if (columnsList.Count != valuesList.Count)
             {
                 throw new InvalidOperationException($"{columns} count should be equal to {values} count");
             }
@@ -30,8 +34,7 @@ namespace SqlKata
 
             ClearComponent("update").AddComponent("update", new InsertClause
             {
-                Columns = columns.ToList(),
-                Values = values.ToList()
+                Data = columnsList.MergeKeysAndValues(valuesList)
             });
 
             return this;
@@ -48,8 +51,7 @@ namespace SqlKata
 
             ClearComponent("update").AddComponent("update", new InsertClause
             {
-                Columns = values.Select(x => x.Key).ToList(),
-                Values = values.Select(x => x.Value).ToList(),
+                Data = values.CreateDictionary()
             });
 
             return this;


### PR DESCRIPTION
Hello, I noticed some performance issue with insert many on big collection. 
It looks like there are few reasons

- unnecessary cast to list
- using string operator instead of string builder
- compilation as .net standard

I fixed first two things, but I didn't change target frameworks, I think it would be good to compile sql kata as multiple frameworks, including .net core 3.1, .net 5.0 and .net 6.0

What I changed

- Add insert many overload
- Use dictionary in insert clause
- Fixed sql server compiler test runner (now every test class have their own instance and legacy pagination is used in tests)
- Improved string build performance