### PR TITLE
compile where clause when no table is present

### DIFF
--- a/QueryBuilder.Tests/SelectTests.cs
+++ b/QueryBuilder.Tests/SelectTests.cs
@@ -832,6 +832,22 @@ namespace SqlKata.Tests
             var c = Compilers.CompileFor(EngineCodes.SqlServer, q);
             Assert.Equal("SELECT [c1]", c.ToString());
         }
+
+        [Fact]
+        public void BasicSelect_WithNoTableAndWhereClause()
+        {
+            var q = new Query().Select("c1").Where("p", 1);
+            var c = Compilers.CompileFor(EngineCodes.SqlServer, q);
+            Assert.Equal("SELECT [c1] WHERE [p] = 1", c.ToString());
+        }
+
+        [Fact]
+        public void BasicSelect_WithNoTableWhereRawClause()
+        {
+            var q = new Query().Select("c1").WhereRaw("1 = 1");
+            var c = Compilers.CompileFor(EngineCodes.SqlServer, q);
+            Assert.Equal("SELECT [c1] WHERE 1 = 1", c.ToString());
+        }
         
     }
 }

--- a/QueryBuilder/Compilers/Compiler.cs
+++ b/QueryBuilder/Compilers/Compiler.cs
@@ -687,7 +687,7 @@ namespace SqlKata.Compilers
 
         public virtual string CompileWheres(SqlResult ctx)
         {
-            if (!ctx.Query.HasComponent("from", EngineCode) || !ctx.Query.HasComponent("where", EngineCode))
+            if (!ctx.Query.HasComponent("where", EngineCode))
             {
                 return null;
             }


### PR DESCRIPTION
this is in continuation of supporting cross apply addressed in #541 

With this PR one can put where clause when there is no table to select

` SELECT 1 WHERE 1=1`