### PR TITLE
Include XML Documentation File

### DIFF
--- a/QueryBuilder/QueryBuilder.csproj
+++ b/QueryBuilder/QueryBuilder.csproj
@@ -24,6 +24,12 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
 
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
+    <DocumentationFile>bin\Debug\netstandard2.0\SqlKata.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
+    <DocumentationFile>bin\Release\netstandard2.0\SqlKata.xml</DocumentationFile>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
   </ItemGroup>

--- a/SqlKata.Execution/SqlKata.Execution.csproj
+++ b/SqlKata.Execution/SqlKata.Execution.csproj
@@ -23,6 +23,12 @@
 
 
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
+    <DocumentationFile>bin\Release\netstandard2.0\SqlKata.Execution.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
+    <DocumentationFile>bin\Debug\netstandard2.0\SqlKata.Execution.xml</DocumentationFile>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\QueryBuilder\QueryBuilder.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Current nuget package does not include the documentation file since it is never generated. 
This prevents consumers from seeing any of the XML documentation provided within the source code.

This PR simply turns that functionality on by placing the files in their respective compile folders