### PR TITLE
Allow quoting identifiers

### DIFF
--- a/QueryBuilder/Compilers/Compiler.cs
+++ b/QueryBuilder/Compilers/Compiler.cs
@@ -7,6 +7,11 @@ namespace SqlKata.Compilers
 {
     public partial class Compiler
     {
+        // As defined [here](https://sqlkata.com/docs/select#identify-columns-and-tables-inside-raw)
+        // the library allows quoting identifiers with `[]` regardless of compiler used.
+        private const string OpeningIdentifierPlaceholder = "[";
+        private const string ClosingIdentifierPlaceholder = "]";
+
         private readonly ConditionsCompilerProvider _compileConditionMethodsProvider;
         protected virtual string parameterPlaceholder { get; set; } = "?";
         protected virtual string parameterPrefix { get; set; } = "@p";
@@ -971,8 +976,8 @@ namespace SqlKata.Compilers
                 .ReplaceIdentifierUnlessEscaped(this.EscapeCharacter, "{", this.OpeningIdentifier)
                 .ReplaceIdentifierUnlessEscaped(this.EscapeCharacter, "}", this.ClosingIdentifier)
 
-                .ReplaceIdentifierUnlessEscaped(this.EscapeCharacter, "[", this.OpeningIdentifier)
-                .ReplaceIdentifierUnlessEscaped(this.EscapeCharacter, "]", this.ClosingIdentifier);
+                .ReplaceIdentifierUnlessEscaped(this.EscapeCharacter, OpeningIdentifierPlaceholder, this.OpeningIdentifier)
+                .ReplaceIdentifierUnlessEscaped(this.EscapeCharacter, ClosingIdentifierPlaceholder, this.ClosingIdentifier);
         }
     }
 }

--- a/QueryBuilder/Compilers/Compiler.cs
+++ b/QueryBuilder/Compilers/Compiler.cs
@@ -891,7 +891,17 @@ namespace SqlKata.Compilers
             var opening = this.OpeningIdentifier;
             var closing = this.ClosingIdentifier;
 
-            return opening + value.Replace(closing, closing + closing) + closing;
+            // If value is already wrapped with opening and closing quotes, remove the quotes to allow escaping of the
+            // remaining quotes the value will be quoted again before returning.
+            if ((value.Substring(0, 1) == opening && value.Substring(value.Length - 1, 1) == closing) ||
+                (value.Substring(0, 1) == OpeningIdentifierPlaceholder && value.Substring(value.Length - 1, 1) == ClosingIdentifierPlaceholder))
+            {
+                value = value.Substring(1, value.Length - 2);
+            }
+
+            var escaped = value.Replace(closing, closing + closing);
+
+            return opening + escaped + closing;
         }
 
         /// <summary>


### PR DESCRIPTION
Currently, SqlKata allows consumers to quote identifiers only within `?Raw` methods.

Due to that when working with identifiers which need to be quoted (whether being keywords or due to casing) separate logic needs to be implemented when calling a non-`Raw` vs a `Raw` method.

This PR allows any identifier to be quoted within the non-`Raw` methods as well.