### PR TITLE
SqlResult Overrides

### DIFF
--- a/QueryBuilder/Compilers/SqlServerCompiler.cs
+++ b/QueryBuilder/Compilers/SqlServerCompiler.cs
@@ -23,10 +23,7 @@ namespace SqlKata.Compilers
 
             query = query.Clone();
 
-            var ctx = new SqlResult
-            {
-                Query = query,
-            };
+            var ctx = GetNewSqlResult(query);
 
             var limit = query.GetLimit(EngineCode);
             var offset = query.GetOffset(EngineCode);
@@ -173,7 +170,7 @@ namespace SqlKata.Compilers
 
         protected override SqlResult CompileAdHocQuery(AdHocTableFromClause adHoc)
         {
-            var ctx = new SqlResult();
+            var ctx = GetNewSqlResult();
 
             var colNames = string.Join(", ", adHoc.Columns.Select(Wrap));
 

--- a/QueryBuilder/Helper.cs
+++ b/QueryBuilder/Helper.cs
@@ -161,6 +161,23 @@ namespace SqlKata
             return Enumerable.Repeat(str, count);
         }
 
+        /// <summary>
+        /// Replace instances of the <paramref name="identifier"/> within the string with the <paramref name="newIdentifier"/>, unless the <paramref name="identifier"/> was escaped via the <paramref name="escapeCharacter"/>
+        /// </summary>
+        /// <param name="input">input string to modify</param>
+        /// <param name="escapeCharacter">escape character to search for within the string</param>
+        /// <param name="identifier">string to search for and replace with <paramref name="newIdentifier"/></param>
+        /// <param name="newIdentifier">string that will replace instances of <paramref name="identifier"/> that have not been escaped</param>
+        /// <returns>
+        ///Example ( Not Escaped ) :
+        ///<br/> Input = [ Test ] , <paramref name="escapeCharacter"/> = '\', <paramref name="identifier"/> = '[', <paramref name="newIdentifier"/> = '{'
+        ///<br/> Result: { Test ]
+        ///<para/>
+        ///Example ( Escaped ) :
+        ///<br/> Input = \[ Test ] , <paramref name="escapeCharacter"/> = '\', <paramref name="identifier"/> = '[', <paramref name="newIdentifier"/> = '{'
+        ///<br/> Result: [ Test ]
+        ///<br/>
+        /// </returns>
         public static string ReplaceIdentifierUnlessEscaped(this string input, string escapeCharacter, string identifier, string newIdentifier)
         {
             //Replace standard, non-escaped identifiers first

--- a/QueryBuilder/SqlResult.cs
+++ b/QueryBuilder/SqlResult.cs
@@ -8,6 +8,8 @@ namespace SqlKata
 {
     public class SqlResult
     {
+        public SqlResult() { }
+
         public Query Query { get; set; }
         public string RawSql { get; set; } = "";
         public List<object> Bindings { get; set; } = new List<object>();
@@ -26,6 +28,7 @@ namespace SqlKata
             typeof(ulong),
         };
 
+        /// <inheritdoc/>
         public override string ToString()
         {
             var deepParameters = Helper.Flatten(Bindings).ToList();
@@ -43,7 +46,12 @@ namespace SqlKata
             });
         }
 
-        private string ChangeToSqlValue(object value)
+        /// <summary>
+        /// Convert each value to its string representation
+        /// </summary>
+        /// <param name="value">value to convert</param>
+        /// <returns>string representation of the <paramref name="value"/></returns>
+        protected virtual string ChangeToSqlValue(object value)
         {
             if (value == null)
             {
@@ -81,7 +89,23 @@ namespace SqlKata
             }
 
             // fallback to string
-            return "'" + value.ToString().Replace("'","''") + "'";
+            return WrapStringValue(value.ToString());
         }
+
+        /// <summary>
+        /// Wrap a string value with identifiers
+        /// </summary>
+        /// <param name="value">string parameter</param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Default Functionality wraps in single quotes
+        /// <br/>   value --> 'value'
+        /// <br/> 'value' --> ''value'''
+        /// </remarks>
+        protected virtual string WrapStringValue(string value)
+        {
+            return "'" + value.ToString().Replace("'", "''") + "'";
+        }
+
     }
 }


### PR DESCRIPTION
While creating a compiler to use with MSAccess, I found that I was having zero search results in all of my queries that used a 'where' statement. 

I tracked the issue down to the SqlResult object using single quotes for strings, as opposed to an escaped double-quote.
`'` vs `\"`

Unfortunately, this was not an 'easy' fix that was built in already due to the method being private, and no easy override available currently. 

This PR adds an overridable method to the compiler that instantiates the SqlResult object. From there, any consumers that need custom wrapping for their values can be easily achieved, just override the `GetNewSqlResult` method to use your custom type.