### PR TITLE
Bump Dapper from 1.50.5 to 2.0.123 in SqlKata.Execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
     <a href="https://www.nuget.org/packages/SqlKata"><img src="https://img.shields.io/nuget/vpre/SqlKata.svg"></a>
     <a href="https://github.com/sqlkata/querybuilder/network/members"><img src="https://img.shields.io/github/forks/sqlkata/querybuilder"></a>
     <a href="https://github.com/sqlkata/querybuilder/stargazers"><img src="https://img.shields.io/github/stars/sqlkata/querybuilder"></a>
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-<a href="#contributors-"><img src="https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square" alt="All Contributors"></a>
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
     <a href="https://twitter.com/intent/tweet?text=Wow:&url=https%3A%2F%2Fgithub.com%2Fsqlkata%2Fquerybuilder"><img alt="Twitter" src="https://img.shields.io/twitter/url?label=Tweet%20about%20SqlKata&style=social&url=https%3A%2F%2Fgithub.com%2Fsqlkata%2Fquerybuilder"></a>		
 </p>
 
@@ -166,23 +163,3 @@ int affected = db.Query("Users").Where("Id", 1).Update(new {
 ```cs
 int affected = db.Query("Users").Where("Id", 1).Delete();
 ```
-
-## Contributors ✨
-
-Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
-
-<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-<!-- prettier-ignore-start -->
-<!-- markdownlint-disable -->
-<table>
-  <tr>
-    <td align="center"><a href="https://github.com/mnsrulz"><img src="https://avatars.githubusercontent.com/u/1809086?v=4?s=100" width="100px;" alt=""/><br /><sub><b>mnsrulz</b></sub></a><br /><a href="https://github.com/sqlkata/querybuilder/commits?author=mnsrulz" title="Code">💻</a></td>
-  </tr>
-</table>
-
-<!-- markdownlint-restore -->
-<!-- prettier-ignore-end -->
-
-<!-- ALL-CONTRIBUTORS-LIST:END -->
-
-This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/SqlKata.Execution/SqlKata.Execution.csproj
+++ b/SqlKata.Execution/SqlKata.Execution.csproj
@@ -32,7 +32,7 @@
     <ProjectReference Include="..\QueryBuilder\QueryBuilder.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="dapper" Version="1.50.5" />
+    <PackageReference Include="dapper" Version="2.0.123" />
     <PackageReference Include="Humanizer.Core" Version="2.8.26" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Bump Dapper from 1.50.5 to 2.0.123 in SqlKata.Execution

## Dapper 2.0.123
- [Release Notes](https://github.com/DapperLib/Dapper/releases/tag/2.0.123)
- [Download and Install](https://www.nuget.org/packages/Dapper/2.0.123)


## Dapper 1.50.5
- [Release Notes](https://github.com/DapperLib/Dapper/releases/tag/1.50.5)
- [Download and Install](https://www.nuget.org/packages/Dapper/1.50.5)