### PR TITLE
update dapper version from 1.50.5 to 2.0.123

### DIFF
--- a/SqlKata.Execution/SqlKata.Execution.csproj
+++ b/SqlKata.Execution/SqlKata.Execution.csproj
@@ -32,7 +32,7 @@
     <ProjectReference Include="..\QueryBuilder\QueryBuilder.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="dapper" Version="1.50.5" />
+    <PackageReference Include="dapper" Version="2.0.123" />
     <PackageReference Include="Humanizer.Core" Version="2.8.26" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
reason: TimeSpan will be parsed as default to :time for Postgres under this version, newer version fixes the issue and sets the default to :interval. (fixed npgsql issue)