### PR TITLE
Iss 507 support filter clause

### DIFF
--- a/QueryBuilder.Tests/SQLiteExecutionTest.cs
+++ b/QueryBuilder.Tests/SQLiteExecutionTest.cs
@@ -207,6 +207,57 @@ namespace SqlKata.Tests
             db.Drop("Transaction");
         }
 
+
+
+        [Fact]
+        public void BasicSelectFilter()
+        {
+            var db = DB().Create("Transaction", new[] {
+                    "Id INTEGER PRIMARY KEY AUTOINCREMENT",
+                    "Date DATE NOT NULL",
+                    "Amount int NOT NULL",
+            });
+
+            var data = new Dictionary<string, int> {
+                // 2020
+                {"2020-01-01", 10},
+                {"2020-05-01", 20},
+                
+                // 2021
+                {"2021-01-01", 40},
+                {"2021-02-01", 10},
+                {"2021-04-01", -10},
+                
+                // 2022
+                {"2022-01-01", 80},
+                {"2022-02-01", -30},
+                {"2022-05-01", 50},
+            };
+
+            foreach (var row in data)
+            {
+                db.Query("Transaction").Insert(new
+                {
+                    Date = row.Key,
+                    Amount = row.Value
+                });
+            }
+
+            var query = db.Query("Transaction")
+                .SelectSum("Amount as Total_2020", q => q.WhereDatePart("year", "date", 2020))
+                .SelectSum("Amount as Total_2021", q => q.WhereDatePart("year", "date", 2021))
+                .SelectSum("Amount as Total_2022", q => q.WhereDatePart("year", "date", 2022))
+                ;
+
+            var results = query.Get().ToList();
+            Assert.Single(results);
+            Assert.Equal(30, results[0].Total_2020);
+            Assert.Equal(40, results[0].Total_2021);
+            Assert.Equal(100, results[0].Total_2022);
+
+            db.Drop("Transaction");
+        }
+
         QueryFactory DB()
         {
             var cs = $"Data Source=file::memory:;Cache=Shared";

--- a/QueryBuilder.Tests/SelectTests.cs
+++ b/QueryBuilder.Tests/SelectTests.cs
@@ -819,7 +819,7 @@ namespace SqlKata.Tests
         [Fact]
         public void BasicSelectRaw_WithNoTable()
         {
-            var q = new Query().SelectRaw("somefunction() as c1");                
+            var q = new Query().SelectRaw("somefunction() as c1");
 
             var c = Compilers.CompileFor(EngineCodes.SqlServer, q);
             Assert.Equal("SELECT somefunction() as c1", c.ToString());
@@ -848,6 +848,60 @@ namespace SqlKata.Tests
             var c = Compilers.CompileFor(EngineCodes.SqlServer, q);
             Assert.Equal("SELECT [c1] WHERE 1 = 1", c.ToString());
         }
-        
+
+        [Fact]
+        public void BasicSelectAggregate()
+        {
+            var q = new Query("Posts").Select("Title")
+                .SelectAggregate("sum", "ViewCount");
+
+            var sqlServer = Compilers.CompileFor(EngineCodes.SqlServer, q);
+            Assert.Equal("SELECT [Title], SUM([ViewCount]) FROM [Posts]", sqlServer.ToString());
+        }
+
+        [Fact]
+        public void SelectAggregateShouldIgnoreEmptyFilter()
+        {
+            var q = new Query("Posts").Select("Title")
+                .SelectAggregate("sum", "ViewCount", q => q);
+
+            var sqlServer = Compilers.CompileFor(EngineCodes.SqlServer, q);
+            Assert.Equal("SELECT [Title], SUM([ViewCount]) FROM [Posts]", sqlServer.ToString());
+        }
+
+        [Fact]
+        public void SelectAggregateShouldIgnoreEmptyQueryFilter()
+        {
+            var q = new Query("Posts").Select("Title")
+                .SelectAggregate("sum", "ViewCount", new Query());
+
+            var sqlServer = Compilers.CompileFor(EngineCodes.SqlServer, q);
+            Assert.Equal("SELECT [Title], SUM([ViewCount]) FROM [Posts]", sqlServer.ToString());
+        }
+
+        [Fact]
+        public void BasicSelectAggregateWithAlias()
+        {
+            var q = new Query("Posts").Select("Title")
+                .SelectAggregate("sum", "ViewCount as TotalViews");
+
+            var sqlServer = Compilers.CompileFor(EngineCodes.SqlServer, q);
+            Assert.Equal("SELECT [Title], SUM([ViewCount]) AS [TotalViews] FROM [Posts]", sqlServer.ToString());
+        }
+
+        [Fact]
+        public void SelectWithFilter()
+        {
+            var q = new Query("Posts").Select("Title")
+                .SelectAggregate("sum", "ViewCount as Published_Jan", q => q.Where("Published_Month", "Jan"))
+                .SelectAggregate("sum", "ViewCount as Published_Feb", q => q.Where("Published_Month", "Feb"));
+
+            var pgSql = Compilers.CompileFor(EngineCodes.PostgreSql, q);
+            Assert.Equal("SELECT \"Title\", SUM(\"ViewCount\") FILTER (WHERE \"Published_Month\" = 'Jan') AS \"Published_Jan\", SUM(\"ViewCount\") FILTER (WHERE \"Published_Month\" = 'Feb') AS \"Published_Feb\" FROM \"Posts\"", pgSql.ToString());
+
+            var sqlServer = Compilers.CompileFor(EngineCodes.SqlServer, q);
+            Assert.Equal("SELECT [Title], SUM(CASE WHEN [Published_Month] = 'Jan' THEN [ViewCount] END) AS [Published_Jan], SUM(CASE WHEN [Published_Month] = 'Feb' THEN [ViewCount] END) AS [Published_Feb] FROM [Posts]", sqlServer.ToString());
+        }
+
     }
 }

--- a/QueryBuilder/Clauses/ColumnClause.cs
+++ b/QueryBuilder/Clauses/ColumnClause.cs
@@ -77,4 +77,33 @@ namespace SqlKata
             };
         }
     }
+
+    /// <summary>
+    /// Represents an aggregated column clause with an optional filter
+    /// </summary>
+    /// <seealso cref="AbstractColumn" />
+    public class AggregatedColumn : AbstractColumn
+    {
+        /// <summary>
+        /// Gets or sets the a query that used to filter the data, 
+        /// the compiler will consider only the `Where` clause.
+        /// </summary>
+        /// <value>
+        /// The filter query.
+        /// </value>
+        public Query Filter { get; set; } = null;
+        public string Aggregate { get; set; }
+        public AbstractColumn Column { get; set; }
+        public override AbstractClause Clone()
+        {
+            return new AggregatedColumn
+            {
+                Engine = Engine,
+                Filter = Filter?.Clone(),
+                Column = Column.Clone() as AbstractColumn,
+                Aggregate = Aggregate,
+                Component = Component,
+            };
+        }
+    }
 }

--- a/QueryBuilder/Compilers/PostgresCompiler.cs
+++ b/QueryBuilder/Compilers/PostgresCompiler.cs
@@ -11,6 +11,7 @@ namespace SqlKata.Compilers
         }
 
         public override string EngineCode { get; } = EngineCodes.PostgreSql;
+        public override bool SupportsFilterClause { get; set; } = true;
 
 
         protected override string CompileBasicStringCondition(SqlResult ctx, BasicStringCondition x)

--- a/QueryBuilder/Compilers/SqliteCompiler.cs
+++ b/QueryBuilder/Compilers/SqliteCompiler.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using SqlKata;
-using SqlKata.Compilers;
 
 namespace SqlKata.Compilers
 {
@@ -10,6 +8,7 @@ namespace SqlKata.Compilers
         protected override string OpeningIdentifier { get; set; } = "\"";
         protected override string ClosingIdentifier { get; set; } = "\"";
         protected override string LastId { get; set; } = "select last_insert_rowid() as id";
+        public override bool SupportsFilterClause { get; set; } = true;
 
         public override string CompileTrue()
         {

--- a/QueryBuilder/Query.Select.cs
+++ b/QueryBuilder/Query.Select.cs
@@ -68,5 +68,54 @@ namespace SqlKata
         {
             return Select(callback.Invoke(NewChild()), alias);
         }
+
+        public Query SelectAggregate(string aggregate, string column, Query filter = null)
+        {
+            Method = "select";
+
+            AddComponent("select", new AggregatedColumn
+            {
+                Column = new Column { Name = column },
+                Aggregate = aggregate,
+                Filter = filter,
+            });
+
+            return this;
+        }
+
+        public Query SelectAggregate(string aggregate, string column, Func<Query, Query> filter)
+        {
+            if (filter == null)
+            {
+                return SelectAggregate(aggregate, column);
+            }
+
+            return SelectAggregate(aggregate, column, filter.Invoke(NewChild()));
+        }
+
+        public Query SelectSum(string column, Func<Query, Query> filter = null)
+        {
+            return SelectAggregate("sum", column, filter);
+        }
+
+        public Query SelectCount(string column, Func<Query, Query> filter = null)
+        {
+            return SelectAggregate("count", column, filter);
+        }
+
+        public Query SelectAvg(string column, Func<Query, Query> filter = null)
+        {
+            return SelectAggregate("avg", column, filter);
+        }
+
+        public Query SelectMin(string column, Func<Query, Query> filter = null)
+        {
+            return SelectAggregate("min", column, filter);
+        }
+
+        public Query SelectMax(string column, Func<Query, Query> filter = null)
+        {
+            return SelectAggregate("max", column, filter);
+        }
     }
 }


### PR DESCRIPTION
This PR adds the support for the `SelectAggregate` method and it's siblings `SelectSum`, `SelectMax`, `SelectMin`, `SelectAvg`, `SelectCount` methods, this is better than using `SelectRaw`.

All these methods accepts an optional `filter` parameter to filter the aggregated column based on a specified conditions, this will translate to the **Aggregation Filter** clause on supported compilers like PostgreSQL, and SQLite with a fallback to `CASE WHEN` statement for the unsupported ones.

Related #507 