### PR TITLE
Iss 581 where exists remove select

### DIFF
--- a/QueryBuilder/Base.Where.cs
+++ b/QueryBuilder/Base.Where.cs
@@ -539,10 +539,6 @@ namespace SqlKata
                 throw new ArgumentException($"'{nameof(FromClause)}' cannot be empty if used inside a '{nameof(WhereExists)}' condition");
             }
 
-            // remove unneeded components
-            query = query.Clone().ClearComponent("select")
-                .SelectRaw("1");
-
             return AddComponent("where", new ExistsCondition
             {
                 Query = query,

--- a/QueryBuilder/Compilers/Compiler.Conditions.cs
+++ b/QueryBuilder/Compilers/Compiler.Conditions.cs
@@ -247,7 +247,16 @@ namespace SqlKata.Compilers
         {
             var op = item.IsNot ? "NOT EXISTS" : "EXISTS";
 
-            var subCtx = CompileSelectQuery(item.Query);
+
+            // remove unneeded components
+            var query = item.Query.Clone();
+
+            if (OmitSelectInsideExists)
+            {
+                query.ClearComponent("select").SelectRaw("1");
+            }
+
+            var subCtx = CompileSelectQuery(query);
 
             ctx.Bindings.AddRange(subCtx.Bindings);
 

--- a/QueryBuilder/Compilers/Compiler.cs
+++ b/QueryBuilder/Compilers/Compiler.cs
@@ -30,6 +30,12 @@ namespace SqlKata.Compilers
         /// <value></value>            
         public virtual bool SupportsFilterClause { get; set; } = false;
 
+        /// <summary>
+        /// If true the compiler will remove the SELECT clause for the query used inside WHERE EXISTS
+        /// </summary>
+        /// <value></value>            
+        public virtual bool OmitSelectInsideExists { get; set; } = true;
+
         protected virtual string SingleRowDummyTableName { get => null; }
 
         /// <summary>


### PR DESCRIPTION
This PR add a new property `OmitSelectInsideExists` to avoid removing the select columns from `WhereExists`
The new property defaults to true to be compatible with previous versions.
related #581 