### PR TITLE
Type attributes cached

### DIFF
--- a/QueryBuilder.Tests/UpdateTests.cs
+++ b/QueryBuilder.Tests/UpdateTests.cs
@@ -1,10 +1,10 @@
+using SqlKata.Compilers;
+using SqlKata.Tests.Infrastructure;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Dynamic;
 using System.Linq;
-using SqlKata.Compilers;
-using SqlKata.Tests.Infrastructure;
 using Xunit;
 
 namespace SqlKata.Tests


### PR DESCRIPTION
While examining the properties, getting property attributes every time was causing slowness in large and batch operations, 
I made it keep the property attributes where it holds the properties.

second call performange;
Before:  00:00:00.0000734
After:    00:00:00.0000310
