### PR TITLE
Aggregate functions condition support added to Having Queries

### DIFF
--- a/QueryBuilder/Clauses/ConditionClause.cs
+++ b/QueryBuilder/Clauses/ConditionClause.cs
@@ -336,4 +336,46 @@ namespace SqlKata
             };
         }
     }
+
+    public class AggregatedCondition : AbstractCondition
+    {
+        /// <summary>
+        /// Gets or sets the a query that used to filter the data, 
+        /// the compiler will consider only the `Where` clause.
+        /// </summary>
+        /// <value>
+        /// The filter query.
+        /// </value>
+        public Query Filter { get; set; } = null;
+
+        /// <summary>
+        /// Gets or sets the keyword of aggregate function.
+        /// </summary>
+        /// <value>
+        /// The keyword of aggregate function, e.g. "COUNT(DISTINCT columnName)", "COUNT(ALL columnName)", etc.
+        /// </value>
+        public string Keyword { get; set; }
+
+        public string Aggregate { get; set; }
+        public string Column { get; set; }
+        public string Operator { get; set; }
+        public object Value { get; set; }
+
+        public override AbstractClause Clone()
+        {
+            return new AggregatedCondition
+            {
+                Filter = Filter?.Clone(),
+                Keyword = Keyword,
+                Aggregate = Aggregate,
+                Column = Column,
+                Operator = Operator,
+                Value = Value,
+                IsOr = IsOr,
+                IsNot = IsNot,
+                Engine = Engine,
+                Component = Component,
+            };
+        }
+    }
 }

--- a/QueryBuilder/Compilers/Compiler.Conditions.cs
+++ b/QueryBuilder/Compilers/Compiler.Conditions.cs
@@ -262,5 +262,26 @@ namespace SqlKata.Compilers
 
             return $"{op} ({subCtx.RawSql})";
         }
+
+        protected virtual string CompileAggregatedCondition(SqlResult ctx, AggregatedCondition item)
+        {
+            if (item is null)
+                return "";
+
+            string aggregate = item.Aggregate.ToUpperInvariant();
+            string keyword = item.Keyword?.PadRight(item.Keyword.Length + 1, ' ').ToUpperInvariant(); // add one space to char end of keyword string, cause of building query
+
+            string filterCondition = CompileHavingFilterConditions(ctx, item);
+
+            if (string.IsNullOrEmpty(filterCondition))
+            {
+                return $"{aggregate}({keyword}{Wrap(item.Column)}) {item.Operator} {item.Value}";
+            }
+
+            var (column, condition) = SplitCondition(filterCondition);
+            return $"{aggregate}({keyword}{column}) {condition}";
+
+        }
+
     }
 }

--- a/QueryBuilder/Compilers/Compiler.cs
+++ b/QueryBuilder/Compilers/Compiler.cs
@@ -571,6 +571,16 @@ namespace SqlKata.Compilers
             return CompileConditions(ctx, wheres);
         }
 
+        protected virtual string CompileHavingFilterConditions(SqlResult ctx, AggregatedCondition aggregatedCondition)
+        {
+            if (aggregatedCondition.Filter is null)
+                return null;
+
+            var wheres = aggregatedCondition.Filter.GetOneComponent<AbstractCondition>("where");
+
+            return CompileCondition(ctx, wheres);
+        }
+
         public virtual SqlResult CompileCte(AbstractFrom cte)
         {
             var ctx = new SqlResult();
@@ -794,18 +804,18 @@ namespace SqlKata.Compilers
             var columns = ctx.Query
                 .GetComponents<AbstractOrderBy>("order", EngineCode)
                 .Select(x =>
-            {
-
-                if (x is RawOrderBy raw)
                 {
-                    ctx.Bindings.AddRange(raw.Bindings);
-                    return WrapIdentifiers(raw.Expression);
-                }
 
-                var direction = (x as OrderBy).Ascending ? "" : " DESC";
+                    if (x is RawOrderBy raw)
+                    {
+                        ctx.Bindings.AddRange(raw.Bindings);
+                        return WrapIdentifiers(raw.Expression);
+                    }
 
-                return Wrap((x as OrderBy).Column) + direction;
-            });
+                    var direction = (x as OrderBy).Ascending ? "" : " DESC";
+
+                    return Wrap((x as OrderBy).Column) + direction;
+                });
 
             return "ORDER BY " + string.Join(", ", columns);
         }
@@ -953,6 +963,20 @@ namespace SqlKata.Compilers
                 var before = value.Substring(0, index);
                 var after = value.Substring(index + 4);
                 return (before, after);
+            }
+
+            return (value, null);
+        }
+
+        public virtual (string, string) SplitCondition(string value)
+        {
+            var splitedValueBySpace = value.Trim().Split(' ');
+
+            if (splitedValueBySpace.Length > 1)
+            {
+                var column = splitedValueBySpace.First().Trim();
+                var condition = value.Substring(column.Length).Trim();
+                return (column, condition);
             }
 
             return (value, null);

--- a/QueryBuilder/Query.Having.cs
+++ b/QueryBuilder/Query.Having.cs
@@ -652,5 +652,259 @@ namespace SqlKata
         }
 
         #endregion
+
+        #region aggregate
+        private Query HavingAggregate(string aggregate, string column = null, string op = null, object value = null, string keyword = null, Query filter = null)
+        {
+            return AddComponent("having", new AggregatedCondition
+            {
+                Aggregate = aggregate,
+                Keyword = keyword,
+                Column = column,
+                Operator = op,
+                Value = value,
+                Filter = filter,
+                IsOr = GetOr(),
+                IsNot = GetNot(),
+            });
+        }
+
+        private Query HavingAggregate(string aggregate, Func<Query, Query> filter, string keyword = null)
+        {
+            if (filter is null)
+                return NewQuery();
+
+            Query queryFilter = queryFilter = filter.Invoke(NewQuery());
+
+            // omit empty queries
+            if (!queryFilter.Clauses.Where(x => x.Component == "where").Any())
+            {
+                return (Query)this;
+            }
+
+            return HavingAggregate(aggregate: aggregate, keyword: keyword, filter: queryFilter);
+        }
+
+        public Query HavingMin(string column, string op, object value)
+        {
+            return HavingAggregate("MIN", column, op, value);
+        }
+
+        public Query HavingMin(Func<Query, Query> filter)
+        {
+            return HavingAggregate("MIN", filter);
+        }
+
+        public Query HavingMax(string column, string op, object value)
+        {
+            return HavingAggregate("MAX", column, op, value);
+        }
+
+        public Query HavingMax(Func<Query, Query> filter)
+        {
+            return HavingAggregate("MAX", filter);
+        }
+
+        public Query HavingCount(string column, string op, object value)
+        {
+            return HavingAggregate("COUNT", column, op, value);
+        }
+
+        public Query HavingCount(Func<Query, Query> filter)
+        {
+            return HavingAggregate("COUNT", filter);
+        }
+
+        public Query HavingDistinctCount(string column, string op, object value)
+        {
+            return HavingAggregate("COUNT", column, op, value, "DISTINCT");
+        }
+
+        public Query HavingDistinctCount(Func<Query, Query> filter)
+        {
+            return HavingAggregate("COUNT", filter, "DISTINCT");
+        }
+
+        public Query HavingAllCount(string column, string op, object value)
+        {
+            return HavingAggregate("COUNT", column, op, value, "ALL");
+        }
+
+        public Query HavingAllCount(Func<Query, Query> filter)
+        {
+            return HavingAggregate("COUNT", filter, "ALL");
+        }
+
+        public Query HavingSum(string column, string op, object value)
+        {
+            return HavingAggregate("SUM", column, op, value);
+        }
+
+        public Query HavingSum(Func<Query, Query> filter)
+        {
+            return HavingAggregate("SUM", filter);
+        }
+
+        public Query HavingDistinctSum(string column, string op, object value)
+        {
+            return HavingAggregate("SUM", column, op, value, "DISTINCT");
+        }
+
+        public Query HavingDistinctSum(Func<Query, Query> filter)
+        {
+            return HavingAggregate("SUM", filter, "DISTINCT");
+        }
+
+        public Query HavingAllSum(string column, string op, object value)
+        {
+            return HavingAggregate("SUM", column, op, value, "ALL");
+        }
+
+        public Query HavingAllSum(Func<Query, Query> filter)
+        {
+            return HavingAggregate("SUM", filter, "ALL");
+        }
+
+        public Query HavingAvg(string column, string op, object value)
+        {
+            return HavingAggregate("AVG", column, op, value);
+        }
+
+        public Query HavingAvg(Func<Query, Query> filter)
+        {
+            return HavingAggregate("AVG", filter);
+        }
+
+        public Query HavingDistinctAvg(string column, string op, object value)
+        {
+            return HavingAggregate("AVG", column, op, value, "DISTINCT");
+        }
+
+        public Query HavingDistinctAvg(Func<Query, Query> filter)
+        {
+            return HavingAggregate("AVG", filter, "DISTINCT");
+        }
+
+        public Query HavingAllAvg(string column, string op, object value)
+        {
+            return HavingAggregate("AVG", column, op, value, "ALL");
+        }
+
+        public Query HavingAllAvg(Func<Query, Query> filter)
+        {
+            return HavingAggregate("AVG", filter, "ALL");
+        }
+
+
+        public Query OrHavingMin(string column, string op, object value)
+        {
+            return Or().HavingAggregate("MIN", column, op, value);
+        }
+
+        public Query OrHavingMin(Func<Query, Query> filter)
+        {
+            return Or().HavingAggregate("MIN", filter);
+        }
+
+        public Query OrHavingMax(string column, string op, object value)
+        {
+            return Or().HavingAggregate("MAX", column, op, value);
+        }
+
+        public Query OrHavingMax(Func<Query, Query> filter)
+        {
+            return Or().HavingAggregate("MAX", filter);
+        }
+
+        public Query OrHavingCount(string column, string op, object value)
+        {
+            return Or().HavingAggregate("COUNT", column, op, value);
+        }
+
+        public Query OrHavingCount(Func<Query, Query> filter)
+        {
+            return Or().HavingAggregate("COUNT", filter);
+        }
+
+        public Query OrHavingDistinctCount(string column, string op, object value)
+        {
+            return Or().HavingAggregate("COUNT", column, op, value, "DISTINCT");
+        }
+
+        public Query OrHavingDistinctCount(Func<Query, Query> filter)
+        {
+            return Or().HavingAggregate("COUNT", filter, "DISTINCT");
+        }
+
+        public Query OrHavingAllCount(string column, string op, object value)
+        {
+            return Or().HavingAggregate("COUNT", column, op, value, "ALL");
+        }
+
+        public Query OrHavingAllCount(Func<Query, Query> filter)
+        {
+            return Or().HavingAggregate("COUNT", filter, "ALL");
+        }
+
+        public Query OrHavingSum(string column, string op, object value)
+        {
+            return Or().HavingAggregate("SUM", column, op, value);
+        }
+
+        public Query OrHavingSum(Func<Query, Query> filter)
+        {
+            return Or().HavingAggregate("SUM", filter);
+        }
+
+        public Query OrHavingDistinctSum(string column, string op, object value)
+        {
+            return Or().HavingAggregate("SUM", column, op, value, "DISTINCT");
+        }
+
+        public Query OrHavingDistinctSum(Func<Query, Query> filter)
+        {
+            return Or().HavingAggregate("SUM", filter, "DISTINCT");
+        }
+
+        public Query OrHavingAllSum(string column, string op, object value)
+        {
+            return Or().HavingAggregate("SUM", column, op, value, "ALL");
+        }
+
+        public Query OrHavingAllSum(Func<Query, Query> filter)
+        {
+            return Or().HavingAggregate("SUM", filter, "ALL");
+        }
+
+        public Query OrHavingAvg(string column, string op, object value)
+        {
+            return Or().HavingAggregate("AVG", column, op, value);
+        }
+
+        public Query OrHavingAvg(Func<Query, Query> filter)
+        {
+            return Or().HavingAggregate("AVG", filter);
+        }
+
+        public Query OrHavingDistinctAvg(string column, string op, object value)
+        {
+            return Or().HavingAggregate("AVG", column, op, value, "DISTINCT");
+        }
+
+        public Query OrHavingDistinctAvg(Func<Query, Query> filter)
+        {
+            return Or().HavingAggregate("AVG", filter, "DISTINCT");
+        }
+
+        public Query OrHavingAllAvg(string column, string op, object value)
+        {
+            return Or().HavingAggregate("AVG", column, op, value, "ALL");
+        }
+
+        public Query OrHavingAllAvg(Func<Query, Query> filter)
+        {
+            return Or().HavingAggregate("AVG", filter, "ALL");
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
Currently, SqlKata consumers have been using HavingRaw to aggregate functions in Having Queries.

I have been fixed this issue. Consumers can now use aggregate functions in Having Queries without using HavingRaw.