### PR TITLE
Fix duplicate column error

### DIFF
--- a/QueryBuilder.Tests/MySqlExecutionTest.cs
+++ b/QueryBuilder.Tests/MySqlExecutionTest.cs
@@ -213,12 +213,12 @@ namespace SqlKata.Tests
                 // 2020
                 {"2020-01-01", 10},
                 {"2020-05-01", 20},
-                
+
                 // 2021
                 {"2021-01-01", 40},
                 {"2021-02-01", 10},
                 {"2021-04-01", -10},
-                
+
                 // 2022
                 {"2022-01-01", 80},
                 {"2022-02-01", -30},
@@ -249,6 +249,25 @@ namespace SqlKata.Tests
             db.Drop("Transaction");
         }
 
+        [Fact]
+        public void ShouldUseSpecifiedColumnsForCountQueryDuringPagination()
+        {
+            var db = DB().Create("Transactions", new[] {
+                    "Id INT PRIMARY KEY AUTO_INCREMENT",
+                    "Date DATE NOT NULL",
+                    "Amount int NOT NULL",
+            });
+
+            var result = db.Query("Transactions as t1")
+                .Distinct()
+                .Select("t1.Id")
+                .Join("Transactions as t2", "t1.Id", "t2.Id", "=")
+                .Paginate<object>(page: 1, perPage: 25, columns: new string[] { "t1.Id" });
+            Assert.Equal(0, result.TotalPages);
+
+            db.Drop("Transactions");
+        }
+
         QueryFactory DB()
         {
             var host = System.Environment.GetEnvironmentVariable("SQLKATA_MYSQL_HOST");
@@ -262,8 +281,5 @@ namespace SqlKata.Tests
 
             return db;
         }
-
-
-
     }
 }

--- a/SqlKata.Execution/Query.Extensions.cs
+++ b/SqlKata.Execution/Query.Extensions.cs
@@ -88,28 +88,48 @@ namespace SqlKata.Execution
             return await FirstAsync<dynamic>(query, transaction, timeout, cancellationToken);
         }
 
-        public static PaginationResult<T> Paginate<T>(this Query query, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null)
+        public static PaginationResult<T> Paginate<T>(this Query query, string[] columns, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null)
         {
             var db = CreateQueryFactory(query);
 
-            return db.Paginate<T>(query, page, perPage, transaction, timeout);
+            return db.Paginate<T>(query, columns, page, perPage, transaction, timeout);
         }
 
-        public static async Task<PaginationResult<T>> PaginateAsync<T>(this Query query, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
+        public static PaginationResult<T> Paginate<T>(this Query query, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null)
+        {
+            return Paginate<T>(query, null, page, perPage, transaction, timeout);
+        }
+
+        public static async Task<PaginationResult<T>> PaginateAsync<T>(this Query query, string[] columns, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
             var db = CreateQueryFactory(query);
 
-            return await db.PaginateAsync<T>(query, page, perPage, transaction, timeout, cancellationToken);
+            return await db.PaginateAsync<T>(query, columns, page, perPage, transaction, timeout, cancellationToken);
+        }
+
+        public static Task<PaginationResult<T>> PaginateAsync<T>(this Query query, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
+        {
+            return PaginateAsync<T>(query, null, page, perPage, transaction, timeout, cancellationToken);
+        }
+
+        public static PaginationResult<dynamic> Paginate(this Query query, string[] columns, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null)
+        {
+            return Paginate<dynamic>(query, columns, page, perPage, transaction, timeout);
         }
 
         public static PaginationResult<dynamic> Paginate(this Query query, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null)
         {
-            return query.Paginate<dynamic>(page, perPage, transaction, timeout);
+            return Paginate<dynamic>(query, null, page, perPage, transaction, timeout);
+        }
+
+        public static async Task<PaginationResult<dynamic>> PaginateAsync(this Query query, string[] columns, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
+        {
+            return await PaginateAsync<dynamic>(query, columns, page, perPage, transaction, timeout, cancellationToken);
         }
 
         public static async Task<PaginationResult<dynamic>> PaginateAsync(this Query query, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
-            return await PaginateAsync<dynamic>(query, page, perPage, transaction, timeout, cancellationToken);
+            return await PaginateAsync<dynamic>(query, null, page, perPage, transaction, timeout, cancellationToken);
         }
 
         public static void Chunk<T>(this Query query, int chunkSize, Func<IEnumerable<T>, int, bool> func, IDbTransaction transaction = null, int? timeout = null)

--- a/SqlKata.Execution/QueryFactory.cs
+++ b/SqlKata.Execution/QueryFactory.cs
@@ -285,7 +285,7 @@ namespace SqlKata.Execution
         public async Task<SqlMapper.GridReader> GetMultipleAsync<T>(
             Query[] queries,
             IDbTransaction transaction = null,
-            int? timeout = null, 
+            int? timeout = null,
             CancellationToken cancellationToken = default)
         {
             var compiled = this.Compiler.Compile(queries);
@@ -324,7 +324,7 @@ namespace SqlKata.Execution
         public async Task<IEnumerable<IEnumerable<T>>> GetAsync<T>(
             Query[] queries,
             IDbTransaction transaction = null,
-            int? timeout = null, 
+            int? timeout = null,
             CancellationToken cancellationToken = default
         )
         {
@@ -388,7 +388,7 @@ namespace SqlKata.Execution
             string aggregateOperation,
             string[] columns = null,
             IDbTransaction transaction = null,
-            int? timeout = null, 
+            int? timeout = null,
             CancellationToken cancellationToken = default
         )
         {
@@ -456,6 +456,11 @@ namespace SqlKata.Execution
 
         public PaginationResult<T> Paginate<T>(Query query, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null)
         {
+            return Paginate<T>(query, null, page, perPage, transaction, timeout);
+        }
+
+        public PaginationResult<T> Paginate<T>(Query query, string[] columns, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null)
+        {
             if (page < 1)
             {
                 throw new ArgumentException("Page param should be greater than or equal to 1", nameof(page));
@@ -466,7 +471,7 @@ namespace SqlKata.Execution
                 throw new ArgumentException("PerPage param should be greater than or equal to 1", nameof(perPage));
             }
 
-            var count = Count<long>(query.Clone(), null, transaction, timeout);
+            var count = Count<long>(query.Clone(), columns, transaction, timeout);
 
             IEnumerable<T> list;
 
@@ -489,7 +494,12 @@ namespace SqlKata.Execution
             };
         }
 
-        public async Task<PaginationResult<T>> PaginateAsync<T>(Query query, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
+        public Task<PaginationResult<T>> PaginateAsync<T>(Query query, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
+        {
+            return PaginateAsync<T>(query, null, page, perPage, transaction, timeout, cancellationToken);
+        }
+
+        public async Task<PaginationResult<T>> PaginateAsync<T>(Query query, string[] columns, int page, int perPage = 25, IDbTransaction transaction = null, int? timeout = null, CancellationToken cancellationToken = default)
         {
             if (page < 1)
             {
@@ -501,7 +511,7 @@ namespace SqlKata.Execution
                 throw new ArgumentException("PerPage param should be greater than or equal to 1", nameof(perPage));
             }
 
-            var count = await CountAsync<long>(query.Clone(), null, transaction, timeout, cancellationToken);
+            var count = await CountAsync<long>(query.Clone(), columns, transaction, timeout, cancellationToken);
 
             IEnumerable<T> list;
 
@@ -553,7 +563,7 @@ namespace SqlKata.Execution
             int chunkSize,
             Func<IEnumerable<T>, int, bool> func,
             IDbTransaction transaction = null,
-            int? timeout = null, 
+            int? timeout = null,
             CancellationToken cancellationToken = default
         )
         {
@@ -592,7 +602,7 @@ namespace SqlKata.Execution
             int chunkSize,
             Action<IEnumerable<T>, int> action,
             IDbTransaction transaction = null,
-            int? timeout = null, 
+            int? timeout = null,
             CancellationToken cancellationToken = default
         )
         {


### PR DESCRIPTION
The `Paginate` method calls the other two methods `Count` and `Get`. If the original query is complex and contains a join of two tables that have at least one column with the same name, a duplicate column error occurs during the count query. For more information, see added test case.