### PR TITLE
Adds multi-row insert with list of dictionaries (#663)

### DIFF
--- a/QueryBuilder.Tests/InsertTests.cs
+++ b/QueryBuilder.Tests/InsertTests.cs
@@ -1,10 +1,10 @@
+using SqlKata.Compilers;
+using SqlKata.Tests.Infrastructure;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Dynamic;
 using System.Linq;
-using SqlKata.Compilers;
-using SqlKata.Tests.Infrastructure;
 using Xunit;
 
 namespace SqlKata.Tests
@@ -281,6 +281,45 @@ namespace SqlKata.Tests
 
             Assert.Equal(
                 "INSERT INTO \"TABLE\" (\"NAME\", \"AGE\") VALUES ('The User', '2018-01-01')",
+                c[EngineCodes.Firebird]);
+        }
+
+        [Fact]
+        public void InsertDictionaryList()
+        {
+            var expensiveCars = new List<Dictionary<string, object>>
+            {
+                new Dictionary<string, object>
+                {
+                    { "name", "Chiron" },
+                    { "brand", "Bugatti" },
+                    { "year", null },
+                },
+                new Dictionary<string, object>
+                {
+                    { "name", "Huayra" },
+                    { "year", 2012 },
+                    { "brand", "Pagani" },
+                },
+                new Dictionary<string, object>
+                {
+                    { "year", 2009 },
+                    { "brand", "Lamborghini" },
+                    { "name", "Reventon roadster" },
+                },
+            };
+
+            var query = new Query("expensive_cars")
+                .AsInsert(expensiveCars);
+
+            var c = Compile(query);
+
+            Assert.Equal(
+                "INSERT INTO [expensive_cars] ([brand], [name], [year]) VALUES ('Bugatti', 'Chiron', NULL), ('Pagani', 'Huayra', 2012), ('Lamborghini', 'Reventon roadster', 2009)",
+                c[EngineCodes.SqlServer]);
+
+            Assert.Equal(
+                "INSERT INTO \"EXPENSIVE_CARS\" (\"BRAND\", \"NAME\", \"YEAR\") SELECT 'Bugatti', 'Chiron', NULL FROM RDB$DATABASE UNION ALL SELECT 'Pagani', 'Huayra', 2012 FROM RDB$DATABASE UNION ALL SELECT 'Lamborghini', 'Reventon roadster', 2009 FROM RDB$DATABASE",
                 c[EngineCodes.Firebird]);
         }
 

--- a/QueryBuilder/Query.Insert.cs
+++ b/QueryBuilder/Query.Insert.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 
 namespace SqlKata
 {
@@ -95,6 +94,47 @@ namespace SqlKata
             }
 
             return this;
+        }
+
+        public Query AsInsert(IEnumerable<IEnumerable<KeyValuePair<string, object>>> values)
+        {
+            if (values == null || !values.Any())
+            {
+                throw new InvalidOperationException($"{values} argument cannot be null or empty");
+            }
+
+            var columnsList = values.First().Select(x => x.Key).OrderBy(x => x).ToList();
+            if (!columnsList.Any())
+            {
+                throw new InvalidOperationException($"Elements in {values} argument cannot be empty");
+            }
+
+            var rowsValuesList = new List<List<object>>();
+
+            foreach (var rowValues in values)
+            {
+                int rowValuesCount = rowValues.Count();
+                if (rowValuesCount != columnsList.Count())
+                {
+                    throw new InvalidOperationException($"Not all elements in {values} contain the same columns.");
+                }
+
+                var valuesList = new List<object>();
+                var sortedRowValuesList = rowValues.OrderBy(x => x.Key).ToList();
+                for (int i = 0; i < rowValuesCount; i++)
+                {
+                    if (columnsList[i] != sortedRowValuesList[i].Key)
+                    {
+                        throw new InvalidOperationException($"Not all elements in {values} contain the same columns.");
+                    }
+
+                    valuesList.Add(sortedRowValuesList[i].Value);
+                }
+
+                rowsValuesList.Add(valuesList);
+            }
+
+            return AsInsert(columnsList, rowsValuesList);
         }
 
         /// <summary>


### PR DESCRIPTION
I ended up figuring it out myself :) seems like this is the only way to catch most of (if not all, since, we never know...) the possible input errors regardless of the implementation passed to the argument. 

It reuses the current overload for insert multi records (the new overload simply calls it after converting the argument into a list of columns and a list of values), so there are not a lot of changes overall. 