### PR TITLE
allow expanded select to be multiline

### DIFF
--- a/QueryBuilder.Tests/SelectTests.cs
+++ b/QueryBuilder.Tests/SelectTests.cs
@@ -75,12 +75,39 @@ namespace SqlKata.Tests
         }
 
         [Fact]
+        public void ExpandedSelectMultiline()
+        {
+            var q = new Query().From("users").Select(@"users.{
+                                                                id,
+                                                                name as Name,
+                                                                age
+                                                              }");
+            var c = Compile(q);
+
+            Assert.Equal("SELECT [users].[id], [users].[name] AS [Name], [users].[age] FROM [users]", c[EngineCodes.SqlServer]);
+            Assert.Equal("SELECT `users`.`id`, `users`.`name` AS `Name`, `users`.`age` FROM `users`", c[EngineCodes.MySql]);
+        }
+
+        [Fact]
         public void ExpandedSelectWithSchema()
         {
             var q = new Query().From("users").Select("dbo.users.{id,name, age}");
             var c = Compile(q);
 
             Assert.Equal("SELECT [dbo].[users].[id], [dbo].[users].[name], [dbo].[users].[age] FROM [users]", c[EngineCodes.SqlServer]);
+        }
+
+        [Fact]
+        public void ExpandedSelectMultilineWithSchema()
+        {
+            var q = new Query().From("users").Select(@"dbo.users.{
+                                                                id,
+                                                                name as Name,
+                                                                age
+                                                              }");
+            var c = Compile(q);
+
+            Assert.Equal("SELECT [dbo].[users].[id], [dbo].[users].[name] AS [Name], [dbo].[users].[age] FROM [users]", c[EngineCodes.SqlServer]);
         }
 
         [Fact]

--- a/QueryBuilder/Helper.cs
+++ b/QueryBuilder/Helper.cs
@@ -136,8 +136,8 @@ namespace SqlKata
 
         public static List<string> ExpandExpression(string expression)
         {
-            var regex = @"^(?:\w+\.){1,2}{(.*)}";
-            var match = Regex.Match(expression, regex);
+            var regex = @"^(?:\w+\.){1,2}{([^}]*)}";
+            var match = Regex.Match(expression, regex, RegexOptions.Multiline);
 
             if (!match.Success)
             {
@@ -149,7 +149,7 @@ namespace SqlKata
 
             var captures = match.Groups[1].Value;
 
-            var cols = Regex.Split(captures, @"\s*,\s*")
+            var cols = Regex.Split(captures, @"\s*,\s*", RegexOptions.Multiline)
                 .Select(x => $"{table}.{x.Trim()}")
                 .ToList();
 


### PR DESCRIPTION
Hi, 

This PR's purpose is to allow expanded select to accept multiline inputs. (currently any multiline expanded select compiles a wrong SQL query)
Expanded select is a great feature for small queries, but for big ones it quickly became complicated to read the query.
For example, the following Query : 
```csharp
var q = new Query().From("users").Select("users.{id,name, age, password, description, admin, last_update, company, title, addr1 as AddressNumber, addr2 as AddressStreet, addr3 as AddressPostalCode, addr4 as AddressCountry, dept, /* other fields */ }");
```
is much more readable this way : 
```csharp
var q = new Query().From("users").Select(@"users.{
          id, name, age, password, description, //allow multiple parameters on the same line
          admin, last_update, //allow multiple lines
          company, title, dept,  
          addr1 as AddressNumber, addr2 as AddressStreet, //allow "as" syntax
          addr3 as AddressPostalCode, addr4 as AddressCountry, 
          /* other fields */
      }");
```

Regards, 

Romain.