### PR TITLE
Restore netstandard2.0 target

### DIFF
--- a/QueryBuilder/QueryBuilder.csproj
+++ b/QueryBuilder/QueryBuilder.csproj
@@ -5,7 +5,7 @@
         <Description>A powerful Dynamic Sql Query Builder supporting SQL Server, MySql, PostgreSql, Sqlite, and Oracle</Description>
         <Authors>Ahmad Moussawi</Authors>
         <Copyright>Copyright (c) 2017 Ahmad Moussawi</Copyright>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
         <RootNamespace>SqlKata</RootNamespace>
         <AssemblyName>SqlKata.Core</AssemblyName>
         <!-- NuGet settings -->

--- a/SqlKata.Execution/SqlKata.Execution.csproj
+++ b/SqlKata.Execution/SqlKata.Execution.csproj
@@ -4,7 +4,7 @@
         <Description>Adds the execution capabilities for SqlKata</Description>
         <Authors>Ahmad Moussawi</Authors>
         <Copyright>Copyright (c) 2017 Ahmad Moussawi</Copyright>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
         <RootNamespace>SqlKata</RootNamespace>
         <!-- NuGet settings -->
         <PackageId>SqlKata.Execution</PackageId>


### PR DESCRIPTION
It would be helpful to put back the netstandard2.0 target, so that projects which do not yet target net8.0 can continue to benefit from bug fixes and new features.

The solution compiles just fine for netstandard2.0, since there are no net8.0-specific methods in use.